### PR TITLE
slight improvements to restart capability and docs

### DIFF
--- a/autotest/test_nhm_restart.py
+++ b/autotest/test_nhm_restart.py
@@ -3,7 +3,11 @@ import pytest
 
 import pywatershed as pws
 
-restart_freqs = ["y", "m", "d"]
+# this module/test can probably be renamed to drop "NHM" at some point. The
+# NHM processes were just a convenient starting place for developing the
+# restart capabilities.
+
+dt_1d = np.timedelta64(24, "h")
 
 # PRMS fails daily restart test starting on many days, including 1979-12-31
 # as documented on nueva: ~/usgs/pywatershed/autotest/prms_restart_transp_on
@@ -21,23 +25,30 @@ nhm_processes = [
     pws.PRMSChannel,
 ]
 
-times_dict = {
+# The domain inputs start on 1979-01-01.
+# These "a", "b", "c" in the restart test cant be achieved with the "f" option.
+# So it is tested separately below. Below we show "start_times" and subtract a
+# day to get init_times, since it's not always obvious what the last day of the
+# month is. Restarts with "y" and "m" are always written on the last day of the
+# period.
+init_times_dict = {
     "d": {
-        "a": np.datetime64("1979-12-31"),
-        "b": np.datetime64("1980-01-01"),
-        "c": np.datetime64("1980-01-02"),
+        "a": np.datetime64("1979-12-31") - dt_1d,
+        "b": np.datetime64("1980-01-01") - dt_1d,
+        "c": np.datetime64("1980-01-02") - dt_1d,
     },
     "m": {
-        "a": np.datetime64("1979-12-31"),
-        "b": np.datetime64("1980-01-01"),
-        "c": np.datetime64("1980-02-01"),
+        "a": np.datetime64("1979-12-31") - dt_1d,
+        "b": np.datetime64("1980-01-01") - dt_1d,
+        "c": np.datetime64("1980-02-01") - dt_1d,
     },
     "y": {
-        "a": np.datetime64("1979-12-31"),
-        "b": np.datetime64("1980-01-01"),
-        "c": np.datetime64("1980-12-31"),
+        "a": np.datetime64("1979-12-31") - dt_1d,
+        "b": np.datetime64("1980-01-01") - dt_1d,
+        "c": np.datetime64("1980-12-31") - dt_1d,
     },
 }
+restart_freqs = list(init_times_dict.keys())
 
 
 def get_control(simulation, init_time=None, end_time=None):
@@ -86,7 +97,7 @@ def test_restart(
     confirm c == c` in all variables. We'll just do that in memory.
     """
 
-    times = times_dict[restart_freq]
+    times = init_times_dict[restart_freq]
 
     output_dir = simulation["output_dir"]
     restart_dir = tmp_path / "restarts"
@@ -191,7 +202,7 @@ def test_restart_f(
     confirm c == c` in all variables. We'll just do that in memory.
     """
 
-    times = {
+    init_times = {
         "a": np.datetime64("1980-01-03"),
         "b": np.datetime64("1980-01-09"),
         "c": np.datetime64("1980-01-19"),
@@ -239,9 +250,9 @@ def test_restart_f(
         proc.finalize()
         return proc
 
-    proc_ac = run_init_end(times["a"], times["c"])
-    _ = run_init_end(times["a"], times["b"], restart_write=True)
-    proc_bc = run_init_end(times["b"], times["c"], restart_read=True)
+    proc_ac = run_init_end(init_times["a"], init_times["c"])
+    _ = run_init_end(init_times["a"], init_times["b"], restart_write=True)
+    proc_bc = run_init_end(init_times["b"], init_times["c"], restart_read=True)
 
     # make sure we all at c
     assert proc_ac.control.current_time == proc_bc.control.current_time

--- a/pywatershed/atmosphere/prms_atmosphere.py
+++ b/pywatershed/atmosphere/prms_atmosphere.py
@@ -82,26 +82,31 @@ class PRMSAtmosphere(Process):
         soltab_horad_potsw: the solar table of potential shortwave
             radiation on a horizontal plane
         verbose: Print extra information or not?
-        restart_read: May be boolean or a Pathlib.Path. If False,
-          control.options will be examined for this key. If True, the working
-          directory is searched for restart files. If a Pathlib.Path, this
-          specifies an alternative directory to search for restart files.
-          Files searched for are of the pattern YYYY-mm-dd-varname.nc where the
-          date is the control.init_time. The timestamp on the file is the valid
-          time of the states in the file with the exception of instantaneous
-          variables from the hourly timesteps (e.g. outflow_ts in PRMSChannel,
-          which is valid at the 23rd hour of the timestampped day).
-        restart_write: As for restart_read but for writing. The directory in
-          either case will be attempted to be created if it does not exist.
-        restart_write_freq: The frequency of restart output as "y" for yearly,
-          "m" for monthly, "d" for daily, or "f" for final. "Final" means that
-          restart files are written with the states of control.end_time to
-          files timestampped the following day. Yearly and monthly restart
-          options write files with timestamps on every first day each year or
-          month during the run. If daily, restarts are written every day. If
-          False, control.options will be examined for this key. If
-          restart_write is not False and restart_write_freq is False, the
-          default of "f" is used.
+        restart_read:
+            May be boolean or a Pathlib.Path. If False, control.options
+            will be examined for this key. If True, the working
+            directory is searched for restart files. If a Pathlib.Path, this
+            specifies an alternative directory to search for restart files.
+            Files searched for are of the pattern YYYY-mm-dd-varname.nc where
+            the date is the control.init_time. The timestamp on the file is the
+            valid time of the states in the file with the exception of
+            processes with sub-daily timesteps. For example, the outflow_ts
+            variable of PRMSChannel is instantaneous and valid at the 23rd hour
+            of the timestampped day whereas its variable seg_outflow is the
+            daily averge value over the timestampped day.
+        restart_write:
+            As for restart_read but for writing. The directory in either
+            case will be attempted to be created if it does not exist.
+        restart_write_freq:
+            If False, then control.options is examined for this key. The
+            follwing values set the frequency of restart output with "y" for
+            yearly, "m" for monthly, "d" for daily, or "f" for final. "Final"
+            means that restart files are written with the states at
+            control.end_time to files timestampped with control.end_time.
+            Yearly and monthly restart options write files with timestamps on
+            the last day of each year or month during the run. If daily,
+            restarts are written every day. If restart_write is not False and
+            restart_write_freq is False, the default of "f" is used.
     """
 
     def __init__(
@@ -910,23 +915,7 @@ class PRMSAtmosphere(Process):
             # <
             self._write_netcdf_timeseries()
 
-        if (
-            hasattr(self, "_restart_write")
-            and self._restart_write is not False
-            and self.control.itime_step >= 0
-        ):
-            if self._restart_write_strf_code == "f":
-                if self.control.itime_step == (self.control.n_times - 1):
-                    self._output_restart()
-            else:
-                current_count = int(
-                    self.control.current_time.astype("datetime64[D]")
-                    .item()
-                    .strftime(self._restart_write_strf_code)
-                )
-                if self._restart_write_strf_code != "%H":
-                    current_count -= 1
-                if current_count == 0:
-                    self._output_restart()
+        # logic for when to write restarts in the function
+        self._output_restart()
 
         return

--- a/pywatershed/base/conservative_process.py
+++ b/pywatershed/base/conservative_process.py
@@ -61,6 +61,31 @@ class ConservativeProcess(Process):
         experimental.
     metadata_patch_conflicts:
         How to handle metadata_patches conflicts. Experimental.
+    restart_read:
+        May be boolean or a Pathlib.Path. If False, control.options
+        will be examined for this key. If True, the working
+        directory is searched for restart files. If a Pathlib.Path, this
+        specifies an alternative directory to search for restart files.
+        Files searched for are of the pattern YYYY-mm-dd-varname.nc where the
+        date is the control.init_time. The timestamp on the file is the valid
+        time of the states in the file with the exception of processes with
+        sub-daily timesteps. For example, the outflow_ts variable of
+        PRMSChannel is instantaneous and valid at the 23rd hour of the
+        timestampped day whereas its variable seg_outflow is the daily averge
+        value over the timestampped day.
+    restart_write:
+        As for restart_read but for writing. The directory in either
+        case will be attempted to be created if it does not exist.
+    restart_write_freq:
+        If False, then control.options is examined for this key. The follwing
+        values set the frequency of restart output with "y" for yearly, "m"
+        for monthly, "d" for daily, or "f" for final. "Final" means that
+        restart files are written with the states at control.end_time to files
+        timestampped with control.end_time. Yearly and monthly restart options
+        write files with timestamps on the last day of each year or month
+        during the run. If daily, restarts are written every day. If
+        restart_write is not False and restart_write_freq is False, the default
+        of "f" is used.
 
     """
 
@@ -74,7 +99,7 @@ class ConservativeProcess(Process):
         metadata_patch_conflicts: Literal["left", "warn", "error"] = "error",
         restart_read: Union[pl.Path, bool] = False,
         restart_write: Union[pl.Path, bool] = False,
-        restart_write_freq: Literal["y", "m", "d", False] = False,
+        restart_write_freq: Literal["y", "m", "d", "f", False] = False,
     ):
         super().__init__(
             control=control,

--- a/pywatershed/base/control.py
+++ b/pywatershed/base/control.py
@@ -85,11 +85,13 @@ class Control(Accessor):
     """Control manages global time and options, and provides metadata.
 
     Args:
-        start_time: the first time of integration NOT the restart time
-        end_time: the last integration time
-        time_step: length of the time step
-        init_time: the initialization time
-        options: a dictionary of global Process options.
+        init_time: The initialization or restart time. Typically one day prior
+          to start_time (but not necessarily).
+        start_time: The first time of model integration, NOT the restart or
+          init time.
+        end_time: The final integration time of the run.
+        time_step: Length of the time step (not currently optional).
+        options: A dictionary of global Process options.
 
     Available pywatershed options:
       * budget_type: one of [None, "warn", "error"]

--- a/pywatershed/base/process.py
+++ b/pywatershed/base/process.py
@@ -93,21 +93,24 @@ class Process(Accessor):
         specifies an alternative directory to search for restart files.
         Files searched for are of the pattern YYYY-mm-dd-varname.nc where the
         date is the control.init_time. The timestamp on the file is the valid
-        time of the states in the file with the exception of instantaneous
-        variables from the hourly timesteps (e.g. outflow_ts in PRMSChannel,
-        which is valid at the 23rd hour of the timestampped day).
+        time of the states in the file with the exception of processes with
+        sub-daily timesteps. For example, the outflow_ts variable of
+        PRMSChannel is instantaneous and valid at the 23rd hour of the
+        timestampped day whereas its variable seg_outflow is the daily averge
+        value over the timestampped day.
     restart_write:
         As for restart_read but for writing. The directory in either
         case will be attempted to be created if it does not exist.
     restart_write_freq:
-        The frequency of restart output as "y" for yearly, "m"
+        If False, then control.options is examined for this key. The follwing
+        values set the frequency of restart output with "y" for yearly, "m"
         for monthly, "d" for daily, or "f" for final. "Final" means that
-        restart files are written with the states of control.end_time to files
-        timestampped the following day. Yearly and monthly restart options
-        write files with timestamps on every first day each year or month
-        during the run. If daily, restarts are written every day. If False,
-        control.options will be examined for this key. If restart_write is not
-        False and restart_write_freq is False, the default of "f" is used.
+        restart files are written with the states at control.end_time to files
+        timestampped with control.end_time. Yearly and monthly restart options
+        write files with timestamps on the last day of each year or month
+        during the run. If daily, restarts are written every day. If
+        restart_write is not False and restart_write_freq is False, the default
+        of "f" is used.
     """
 
     def __init__(
@@ -212,24 +215,7 @@ class Process(Accessor):
                 print(f"writing output for: {self.name}")
             self._output_netcdf()
 
-        if (
-            hasattr(self, "_restart_write")
-            and self._restart_write is not False
-            and self.control.itime_step >= 0
-        ):
-            if self._restart_write_strf_code == "f":
-                if self.control.itime_step == (self.control.n_times - 1):
-                    self._output_restart()
-            else:
-                current_count = int(
-                    self.control.current_time.astype("datetime64[D]")
-                    .item()
-                    .strftime(self._restart_write_strf_code)
-                )
-                if self._restart_write_strf_code != "%H":
-                    current_count -= 1
-                if current_count == 0:
-                    self._output_restart()
+        self._output_restart()
 
         return
 
@@ -719,6 +705,33 @@ class Process(Accessor):
 
     def _output_restart(self) -> None:
         from xarray import DataArray
+
+        # preamble is logic for outputting restarts, or not.
+        if (
+            hasattr(self, "_restart_write")
+            and self._restart_write is not False
+            and self.control.itime_step >= 0
+        ):
+            if self._restart_write_strf_code == "f":
+                if self.control.itime_step != (self.control.n_times - 1):
+                    return
+            else:
+                next_count = int(
+                    # write restarts on the LAST day of the period, so
+                    # add a day to current time
+                    (self.control.current_time + np.timedelta64(24, "h"))
+                    .astype("datetime64[D]")
+                    .item()
+                    .strftime(self._restart_write_strf_code)
+                )
+                if self._restart_write_strf_code != "%H":
+                    # because hours are counted from zero but days are not
+                    next_count -= 1
+                if next_count != 0:
+                    return
+
+        else:
+            return
 
         cur_time = self.control.current_time
         time = np.atleast_1d(np.array(cur_time.astype("datetime64[ns]")))

--- a/pywatershed/hydrology/prms_canopy.py
+++ b/pywatershed/hydrology/prms_canopy.py
@@ -63,26 +63,31 @@ class PRMSCanopy(ConservativeProcess):
             "numba".
         verbose: Print extra information or not?
         load_n_time_batches: not-implemented
-        restart_read: May be boolean or a Pathlib.Path. If False,
-          control.options will be examined for this key. If True, the working
-          directory is searched for restart files. If a Pathlib.Path, this
-          specifies an alternative directory to search for restart files.
-          Files searched for are of the pattern YYYY-mm-dd-varname.nc where the
-          date is the control.init_time. The timestamp on the file is the valid
-          time of the states in the file with the exception of instantaneous
-          variables from the hourly timesteps (e.g. outflow_ts in PRMSChannel,
-          which is valid at the 23rd hour of the timestampped day).
-        restart_write: As for restart_read but for writing. The directory in
-          either case will be attempted to be created if it does not exist.
-        restart_write_freq: The frequency of restart output as "y" for yearly,
-          "m" for monthly, "d" for daily, or "f" for final. "Final" means that
-          restart files are written with the states of control.end_time to
-          files timestampped the following day. Yearly and monthly restart
-          options write files with timestamps on every first day each year or
-          month during the run. If daily, restarts are written every day. If
-          False, control.options will be examined for this key. If
-          restart_write is not False and restart_write_freq is False, the
-          default of "f" is used.
+        restart_read:
+            May be boolean or a Pathlib.Path. If False, control.options
+            will be examined for this key. If True, the working
+            directory is searched for restart files. If a Pathlib.Path, this
+            specifies an alternative directory to search for restart files.
+            Files searched for are of the pattern YYYY-mm-dd-varname.nc where
+            the date is the control.init_time. The timestamp on the file is the
+            valid time of the states in the file with the exception of
+            processes with sub-daily timesteps. For example, the outflow_ts
+            variable of PRMSChannel is instantaneous and valid at the 23rd hour
+            of the timestampped day whereas its variable seg_outflow is the
+            daily averge value over the timestampped day.
+        restart_write:
+            As for restart_read but for writing. The directory in either
+            case will be attempted to be created if it does not exist.
+        restart_write_freq:
+            If False, then control.options is examined for this key. The
+            follwing values set the frequency of restart output with "y" for
+            yearly, "m" for monthly, "d" for daily, or "f" for final. "Final"
+            means that restart files are written with the states at
+            control.end_time to files timestampped with control.end_time.
+            Yearly and monthly restart options write files with timestamps on
+            the last day of each year or month during the run. If daily,
+            restarts are written every day. If restart_write is not False and
+            restart_write_freq is False, the default of "f" is used.
     """
 
     def __init__(
@@ -103,8 +108,8 @@ class PRMSCanopy(ConservativeProcess):
         verbose: bool = None,
         restart_read: Union[pl.Path, bool] = False,
         restart_write: Union[pl.Path, bool] = False,
-        restart_write_freq: Literal["y", "m", "d"] = False,
-    ):
+        restart_write_freq: Literal["y", "m", "d", "f", False] = False,
+    ) -> None:
         super().__init__(
             control=control,
             discretization=discretization,

--- a/pywatershed/hydrology/prms_channel.py
+++ b/pywatershed/hydrology/prms_channel.py
@@ -88,26 +88,31 @@ class PRMSChannel(ConservativeProcess):
             selected then no parameters are adjusted and there will be no
             warnings or errors.
         verbose: Print extra information or not?
-        restart_read: May be boolean or a Pathlib.Path. If False,
-          control.options will be examined for this key. If True, the working
-          directory is searched for restart files. If a Pathlib.Path, this
-          specifies an alternative directory to search for restart files.
-          Files searched for are of the pattern YYYY-mm-dd-varname.nc where the
-          date is the control.init_time. The timestamp on the file is the valid
-          time of the states in the file with the exception of instantaneous
-          variables from the hourly timesteps (e.g. outflow_ts in PRMSChannel,
-          which is valid at the 23rd hour of the timestampped day).
-        restart_write: As for restart_read but for writing. The directory in
-          either case will be attempted to be created if it does not exist.
-        restart_write_freq: The frequency of restart output as "y" for yearly,
-          "m" for monthly, "d" for daily, or "f" for final. "Final" means that
-          restart files are written with the states of control.end_time to
-          files timestampped the following day. Yearly and monthly restart
-          options write files with timestamps on every first day each year or
-          month during the run. If daily, restarts are written every day. If
-          False, control.options will be examined for this key. If
-          restart_write is not False and restart_write_freq is False, the
-          default of "f" is used.
+        restart_read:
+            May be boolean or a Pathlib.Path. If False, control.options
+            will be examined for this key. If True, the working
+            directory is searched for restart files. If a Pathlib.Path, this
+            specifies an alternative directory to search for restart files.
+            Files searched for are of the pattern YYYY-mm-dd-varname.nc where
+            the date is the control.init_time. The timestamp on the file is the
+            valid time of the states in the file with the exception of
+            processes with sub-daily timesteps. For example, the outflow_ts
+            variable of PRMSChannel is instantaneous and valid at the 23rd hour
+            of the timestampped day whereas its variable seg_outflow is the
+            daily averge value over the timestampped day.
+        restart_write:
+            As for restart_read but for writing. The directory in either
+            case will be attempted to be created if it does not exist.
+        restart_write_freq:
+            If False, then control.options is examined for this key. The
+            follwing values set the frequency of restart output with "y" for
+            yearly, "m" for monthly, "d" for daily, or "f" for final. "Final"
+            means that restart files are written with the states at
+            control.end_time to files timestampped with control.end_time.
+            Yearly and monthly restart options write files with timestamps on
+            the last day of each year or month during the run. If daily,
+            restarts are written every day. If restart_write is not False and
+            restart_write_freq is False, the default of "f" is used.
     """
 
     def __init__(
@@ -124,7 +129,7 @@ class PRMSChannel(ConservativeProcess):
         verbose: bool = None,
         restart_read: Union[pl.Path, bool] = False,
         restart_write: Union[pl.Path, bool] = False,
-        restart_write_freq: Literal["y", "m", "d", False] = False,
+        restart_write_freq: Literal["y", "m", "d", "f", False] = False,
     ) -> None:
         super().__init__(
             control=control,

--- a/pywatershed/hydrology/prms_groundwater.py
+++ b/pywatershed/hydrology/prms_groundwater.py
@@ -47,26 +47,31 @@ class PRMSGroundwater(ConservativeProcess):
         calc_method: one of ["fortran", "numba", "numpy"]. None defaults to
             "numba".
         verbose: Print extra information or not?
-        restart_read: May be boolean or a Pathlib.Path. If False,
-          control.options will be examined for this key. If True, the working
-          directory is searched for restart files. If a Pathlib.Path, this
-          specifies an alternative directory to search for restart files.
-          Files searched for are of the pattern YYYY-mm-dd-varname.nc where the
-          date is the control.init_time. The timestamp on the file is the valid
-          time of the states in the file with the exception of instantaneous
-          variables from the hourly timesteps (e.g. outflow_ts in PRMSChannel,
-          which is valid at the 23rd hour of the timestampped day).
-        restart_write: As for restart_read but for writing. The directory in
-          either case will be attempted to be created if it does not exist.
-        restart_write_freq: The frequency of restart output as "y" for yearly,
-          "m" for monthly, "d" for daily, or "f" for final. "Final" means that
-          restart files are written with the states of control.end_time to
-          files timestampped the following day. Yearly and monthly restart
-          options write files with timestamps on every first day each year or
-          month during the run. If daily, restarts are written every day. If
-          False, control.options will be examined for this key. If
-          restart_write is not False and restart_write_freq is False, the
-          default of "f" is used.
+        restart_read:
+            May be boolean or a Pathlib.Path. If False, control.options
+            will be examined for this key. If True, the working
+            directory is searched for restart files. If a Pathlib.Path, this
+            specifies an alternative directory to search for restart files.
+            Files searched for are of the pattern YYYY-mm-dd-varname.nc where
+            the date is the control.init_time. The timestamp on the file is the
+            valid time of the states in the file with the exception of
+            processes with sub-daily timesteps. For example, the outflow_ts
+            variable of PRMSChannel is instantaneous and valid at the 23rd hour
+            of the timestampped day whereas its variable seg_outflow is the
+            daily averge value over the timestampped day.
+        restart_write:
+            As for restart_read but for writing. The directory in either
+            case will be attempted to be created if it does not exist.
+        restart_write_freq:
+            If False, then control.options is examined for this key. The
+            follwing values set the frequency of restart output with "y" for
+            yearly, "m" for monthly, "d" for daily, or "f" for final. "Final"
+            means that restart files are written with the states at
+            control.end_time to files timestampped with control.end_time.
+            Yearly and monthly restart options write files with timestamps on
+            the last day of each year or month during the run. If daily,
+            restarts are written every day. If restart_write is not False and
+            restart_write_freq is False, the default of "f" is used.
     """
 
     def __init__(
@@ -83,7 +88,7 @@ class PRMSGroundwater(ConservativeProcess):
         verbose: bool = None,
         restart_read: Union[pl.Path, bool] = False,
         restart_write: Union[pl.Path, bool] = False,
-        restart_write_freq: Literal["y", "m", "d", False] = False,
+        restart_write_freq: Literal["y", "m", "d", "f", False] = False,
     ) -> None:
         super().__init__(
             control=control,

--- a/pywatershed/hydrology/prms_groundwater_no_dprst.py
+++ b/pywatershed/hydrology/prms_groundwater_no_dprst.py
@@ -1,4 +1,5 @@
-from typing import Literal
+import pathlib as pl
+from typing import Literal, Union
 
 from ..base.adapter import adaptable
 from ..base.control import Control
@@ -36,26 +37,31 @@ class PRMSGroundwaterNoDprst(PRMSGroundwater):
         calc_method: one of ["fortran", "numba", "numpy"]. None defaults to
             "numba".
         verbose: Print extra information or not?
-        restart_read: May be boolean or a Pathlib.Path. If False,
-          control.options will be examined for this key. If True, the working
-          directory is searched for restart files. If a Pathlib.Path, this
-          specifies an alternative directory to search for restart files.
-          Files searched for are of the pattern YYYY-mm-dd-varname.nc where the
-          date is the control.init_time. The timestamp on the file is the valid
-          time of the states in the file with the exception of instantaneous
-          variables from the hourly timesteps (e.g. outflow_ts in PRMSChannel,
-          which is valid at the 23rd hour of the timestampped day).
-        restart_write: As for restart_read but for writing. The directory in
-          either case will be attempted to be created if it does not exist.
-        restart_write_freq: The frequency of restart output as "y" for yearly,
-          "m" for monthly, "d" for daily, or "f" for final. "Final" means that
-          restart files are written with the states of control.end_time to
-          files timestampped the following day. Yearly and monthly restart
-          options write files with timestamps on every first day each year or
-          month during the run. If daily, restarts are written every day. If
-          False, control.options will be examined for this key. If
-          restart_write is not False and restart_write_freq is False, the
-          default of "f" is used.
+        restart_read:
+            May be boolean or a Pathlib.Path. If False, control.options
+            will be examined for this key. If True, the working
+            directory is searched for restart files. If a Pathlib.Path, this
+            specifies an alternative directory to search for restart files.
+            Files searched for are of the pattern YYYY-mm-dd-varname.nc where
+            the date is the control.init_time. The timestamp on the file is the
+            valid time of the states in the file with the exception of
+            processes with sub-daily timesteps. For example, the outflow_ts
+            variable of PRMSChannel is instantaneous and valid at the 23rd hour
+            of the timestampped day whereas its variable seg_outflow is the
+            daily averge value over the timestampped day.
+        restart_write:
+            As for restart_read but for writing. The directory in either
+            case will be attempted to be created if it does not exist.
+        restart_write_freq:
+            If False, then control.options is examined for this key. The
+            follwing values set the frequency of restart output with "y" for
+            yearly, "m" for monthly, "d" for daily, or "f" for final. "Final"
+            means that restart files are written with the states at
+            control.end_time to files timestampped with control.end_time.
+            Yearly and monthly restart options write files with timestamps on
+            the last day of each year or month during the run. If daily,
+            restarts are written every day. If restart_write is not False and
+            restart_write_freq is False, the default of "f" is used.
     """
 
     def __init__(
@@ -68,6 +74,9 @@ class PRMSGroundwaterNoDprst(PRMSGroundwater):
         budget_type: Literal["defer", None, "warn", "error"] = "defer",
         calc_method: Literal["fortran", "numba", "numpy"] = None,
         verbose: bool = None,
+        restart_read: Union[pl.Path, bool] = False,
+        restart_write: Union[pl.Path, bool] = False,
+        restart_write_freq: Literal["y", "m", "d", "f", False] = False,
     ) -> None:
         self._dprst_flag = False
 
@@ -81,6 +90,9 @@ class PRMSGroundwaterNoDprst(PRMSGroundwater):
             budget_type=budget_type,
             calc_method=calc_method,
             verbose=verbose,
+            restart_read=restart_read,
+            restart_write=restart_write,
+            restart_write_freq=restart_write_freq,
         )
 
         self.name = "PRMSGroundwaterNoDprst"

--- a/pywatershed/hydrology/prms_runoff.py
+++ b/pywatershed/hydrology/prms_runoff.py
@@ -73,26 +73,31 @@ class PRMSRunoff(ConservativeProcess):
         calc_method: one of ["numba", "numpy"]. None defaults to
             "numba".
         verbose: Print extra information or not?
-        restart_read: May be boolean or a Pathlib.Path. If False,
-          control.options will be examined for this key. If True, the working
-          directory is searched for restart files. If a Pathlib.Path, this
-          specifies an alternative directory to search for restart files.
-          Files searched for are of the pattern YYYY-mm-dd-varname.nc where the
-          date is the control.init_time. The timestamp on the file is the valid
-          time of the states in the file with the exception of instantaneous
-          variables from the hourly timesteps (e.g. outflow_ts in PRMSChannel,
-          which is valid at the 23rd hour of the timestampped day).
-        restart_write: As for restart_read but for writing. The directory in
-          either case will be attempted to be created if it does not exist.
-        restart_write_freq: The frequency of restart output as "y" for yearly,
-          "m" for monthly, "d" for daily, or "f" for final. "Final" means that
-          restart files are written with the states of control.end_time to
-          files timestampped the following day. Yearly and monthly restart
-          options write files with timestamps on every first day each year or
-          month during the run. If daily, restarts are written every day. If
-          False, control.options will be examined for this key. If
-          restart_write is not False and restart_write_freq is False, the
-          default of "f" is used.
+        restart_read:
+            May be boolean or a Pathlib.Path. If False, control.options
+            will be examined for this key. If True, the working
+            directory is searched for restart files. If a Pathlib.Path, this
+            specifies an alternative directory to search for restart files.
+            Files searched for are of the pattern YYYY-mm-dd-varname.nc where
+            the date is the control.init_time. The timestamp on the file is the
+            valid time of the states in the file with the exception of
+            processes with sub-daily timesteps. For example, the outflow_ts
+            variable of PRMSChannel is instantaneous and valid at the 23rd hour
+            of the timestampped day whereas its variable seg_outflow is the
+            daily averge value over the timestampped day.
+        restart_write:
+            As for restart_read but for writing. The directory in either
+            case will be attempted to be created if it does not exist.
+        restart_write_freq:
+            If False, then control.options is examined for this key. The
+            follwing values set the frequency of restart output with "y" for
+            yearly, "m" for monthly, "d" for daily, or "f" for final. "Final"
+            means that restart files are written with the states at
+            control.end_time to files timestampped with control.end_time.
+            Yearly and monthly restart options write files with timestamps on
+            the last day of each year or month during the run. If daily,
+            restarts are written every day. If restart_write is not False and
+            restart_write_freq is False, the default of "f" is used.
     """
 
     def __init__(
@@ -120,7 +125,7 @@ class PRMSRunoff(ConservativeProcess):
         verbose: bool = None,
         restart_read: Union[pl.Path, bool] = False,
         restart_write: Union[pl.Path, bool] = False,
-        restart_write_freq: Literal["y", "m", "d", None] = None,
+        restart_write_freq: Literal["y", "m", "d", "f", False] = False,
     ) -> None:
         self._dprst_flag = dprst_flag
         if self._dprst_flag is None:

--- a/pywatershed/hydrology/prms_runoff_no_dprst.py
+++ b/pywatershed/hydrology/prms_runoff_no_dprst.py
@@ -1,4 +1,5 @@
-from typing import Literal
+import pathlib as pl
+from typing import Literal, Union
 
 from ..base.adapter import adaptable
 from ..base.control import Control
@@ -66,26 +67,31 @@ class PRMSRunoffNoDprst(PRMSRunoff):
         calc_method: one of ["fortran", "numba", "numpy"]. None defaults to
             "numba".
         verbose: Print extra information or not?
-        restart_read: May be boolean or a Pathlib.Path. If False,
-          control.options will be examined for this key. If True, the working
-          directory is searched for restart files. If a Pathlib.Path, this
-          specifies an alternative directory to search for restart files.
-          Files searched for are of the pattern YYYY-mm-dd-varname.nc where the
-          date is the control.init_time. The timestamp on the file is the valid
-          time of the states in the file with the exception of instantaneous
-          variables from the hourly timesteps (e.g. outflow_ts in PRMSChannel,
-          which is valid at the 23rd hour of the timestampped day).
-        restart_write: As for restart_read but for writing. The directory in
-          either case will be attempted to be created if it does not exist.
-        restart_write_freq: The frequency of restart output as "y" for yearly,
-          "m" for monthly, "d" for daily, or "f" for final. "Final" means that
-          restart files are written with the states of control.end_time to
-          files timestampped the following day. Yearly and monthly restart
-          options write files with timestamps on every first day each year or
-          month during the run. If daily, restarts are written every day. If
-          False, control.options will be examined for this key. If
-          restart_write is not False and restart_write_freq is False, the
-          default of "f" is used.
+        restart_read:
+            May be boolean or a Pathlib.Path. If False, control.options
+            will be examined for this key. If True, the working
+            directory is searched for restart files. If a Pathlib.Path, this
+            specifies an alternative directory to search for restart files.
+            Files searched for are of the pattern YYYY-mm-dd-varname.nc where
+            the date is the control.init_time. The timestamp on the file is the
+            valid time of the states in the file with the exception of
+            processes with sub-daily timesteps. For example, the outflow_ts
+            variable of PRMSChannel is instantaneous and valid at the 23rd hour
+            of the timestampped day whereas its variable seg_outflow is the
+            daily averge value over the timestampped day.
+        restart_write:
+            As for restart_read but for writing. The directory in either
+            case will be attempted to be created if it does not exist.
+        restart_write_freq:
+            If False, then control.options is examined for this key. The
+            follwing values set the frequency of restart output with "y" for
+            yearly, "m" for monthly, "d" for daily, or "f" for final. "Final"
+            means that restart files are written with the states at
+            control.end_time to files timestampped with control.end_time.
+            Yearly and monthly restart options write files with timestamps on
+            the last day of each year or month during the run. If daily,
+            restarts are written every day. If restart_write is not False and
+            restart_write_freq is False, the default of "f" is used.
     """
 
     def __init__(
@@ -110,6 +116,9 @@ class PRMSRunoffNoDprst(PRMSRunoff):
         budget_type: Literal["defer", None, "warn", "error"] = "defer",
         calc_method: Literal["numba", "numpy"] = None,
         verbose: bool = None,
+        restart_read: Union[pl.Path, bool] = False,
+        restart_write: Union[pl.Path, bool] = False,
+        restart_write_freq: Literal["y", "m", "d", "f", False] = False,
     ) -> None:
         self._dprst_flag = False
 
@@ -135,6 +144,9 @@ class PRMSRunoffNoDprst(PRMSRunoff):
             budget_type=budget_type,
             calc_method=calc_method,
             verbose=verbose,
+            restart_read=restart_read,
+            restart_write=restart_write,
+            restart_write_freq=restart_write_freq,
         )
 
         self.name = "PRMSRunoffNoDprst"

--- a/pywatershed/hydrology/prms_snow.py
+++ b/pywatershed/hydrology/prms_snow.py
@@ -118,26 +118,31 @@ class PRMSSnow(ConservativeProcess):
         calc_method: one of ["fortran", "numba", "numpy"]. None defaults to
             "numba".
         verbose: Print extra information or not?
-        restart_read: May be boolean or a Pathlib.Path. If False,
-          control.options will be examined for this key. If True, the working
-          directory is searched for restart files. If a Pathlib.Path, this
-          specifies an alternative directory to search for restart files.
-          Files searched for are of the pattern YYYY-mm-dd-varname.nc where the
-          date is the control.init_time. The timestamp on the file is the valid
-          time of the states in the file with the exception of instantaneous
-          variables from the hourly timesteps (e.g. outflow_ts in PRMSChannel,
-          which is valid at the 23rd hour of the timestampped day).
-        restart_write: As for restart_read but for writing. The directory in
-          either case will be attempted to be created if it does not exist.
-        restart_write_freq: The frequency of restart output as "y" for yearly,
-          "m" for monthly, "d" for daily, or "f" for final. "Final" means that
-          restart files are written with the states of control.end_time to
-          files timestampped the following day. Yearly and monthly restart
-          options write files with timestamps on every first day each year or
-          month during the run. If daily, restarts are written every day. If
-          False, control.options will be examined for this key. If
-          restart_write is not False and restart_write_freq is False, the
-          default of "f" is used.
+        restart_read:
+            May be boolean or a Pathlib.Path. If False, control.options
+            will be examined for this key. If True, the working
+            directory is searched for restart files. If a Pathlib.Path, this
+            specifies an alternative directory to search for restart files.
+            Files searched for are of the pattern YYYY-mm-dd-varname.nc where
+            the date is the control.init_time. The timestamp on the file is the
+            valid time of the states in the file with the exception of
+            processes with sub-daily timesteps. For example, the outflow_ts
+            variable of PRMSChannel is instantaneous and valid at the 23rd hour
+            of the timestampped day whereas its variable seg_outflow is the
+            daily averge value over the timestampped day.
+        restart_write:
+            As for restart_read but for writing. The directory in either
+            case will be attempted to be created if it does not exist.
+        restart_write_freq:
+            If False, then control.options is examined for this key. The
+            follwing values set the frequency of restart output with "y" for
+            yearly, "m" for monthly, "d" for daily, or "f" for final. "Final"
+            means that restart files are written with the states at
+            control.end_time to files timestampped with control.end_time.
+            Yearly and monthly restart options write files with timestamps on
+            the last day of each year or month during the run. If daily,
+            restarts are written every day. If restart_write is not False and
+            restart_write_freq is False, the default of "f" is used.
     """
 
     def __init__(
@@ -165,8 +170,8 @@ class PRMSSnow(ConservativeProcess):
         verbose: bool = None,
         restart_read: Union[pl.Path, bool] = False,
         restart_write: Union[pl.Path, bool] = False,
-        restart_write_freq: Literal["y", "m", "d"] = False,
-    ) -> "PRMSSnow":
+        restart_write_freq: Literal["y", "m", "d", "f", False] = False,
+    ):
         super().__init__(
             control=control,
             discretization=discretization,

--- a/pywatershed/hydrology/prms_soilzone.py
+++ b/pywatershed/hydrology/prms_soilzone.py
@@ -77,26 +77,31 @@ class PRMSSoilzone(ConservativeProcess):
             selected then no parameters are adjusted and there will be no
             warnings or errors.
         verbose: Print extra information or not?
-        restart_read: May be boolean or a Pathlib.Path. If False,
-          control.options will be examined for this key. If True, the working
-          directory is searched for restart files. If a Pathlib.Path, this
-          specifies an alternative directory to search for restart files.
-          Files searched for are of the pattern YYYY-mm-dd-varname.nc where the
-          date is the control.init_time. The timestamp on the file is the valid
-          time of the states in the file with the exception of instantaneous
-          variables from the hourly timesteps (e.g. outflow_ts in PRMSChannel,
-          which is valid at the 23rd hour of the timestampped day).
-        restart_write: As for restart_read but for writing. The directory in
-          either case will be attempted to be created if it does not exist.
-        restart_write_freq: The frequency of restart output as "y" for yearly,
-          "m" for monthly, "d" for daily, or "f" for final. "Final" means that
-          restart files are written with the states of control.end_time to
-          files timestampped the following day. Yearly and monthly restart
-          options write files with timestamps on every first day each year or
-          month during the run. If daily, restarts are written every day. If
-          False, control.options will be examined for this key. If
-          restart_write is not False and restart_write_freq is False, the
-          default of "f" is used.
+        restart_read:
+            May be boolean or a Pathlib.Path. If False, control.options
+            will be examined for this key. If True, the working
+            directory is searched for restart files. If a Pathlib.Path, this
+            specifies an alternative directory to search for restart files.
+            Files searched for are of the pattern YYYY-mm-dd-varname.nc where
+            the date is the control.init_time. The timestamp on the file is the
+            valid time of the states in the file with the exception of
+            processes with sub-daily timesteps. For example, the outflow_ts
+            variable of PRMSChannel is instantaneous and valid at the 23rd hour
+            of the timestampped day whereas its variable seg_outflow is the
+            daily averge value over the timestampped day.
+        restart_write:
+            As for restart_read but for writing. The directory in either
+            case will be attempted to be created if it does not exist.
+        restart_write_freq:
+            If False, then control.options is examined for this key. The
+            follwing values set the frequency of restart output with "y" for
+            yearly, "m" for monthly, "d" for daily, or "f" for final. "Final"
+            means that restart files are written with the states at
+            control.end_time to files timestampped with control.end_time.
+            Yearly and monthly restart options write files with timestamps on
+            the last day of each year or month during the run. If daily,
+            restarts are written every day. If restart_write is not False and
+            restart_write_freq is False, the default of "f" is used.
     """
 
     def __init__(
@@ -122,8 +127,8 @@ class PRMSSoilzone(ConservativeProcess):
         verbose: bool = None,
         restart_read: Union[pl.Path, bool] = False,
         restart_write: Union[pl.Path, bool] = False,
-        restart_write_freq: Literal["y", "m", "d"] = False,
-    ) -> "PRMSSoilzone":
+        restart_write_freq: Literal["y", "m", "d", "f", False] = False,
+    ):
         super().__init__(
             control=control,
             discretization=discretization,

--- a/pywatershed/hydrology/prms_soilzone_no_dprst.py
+++ b/pywatershed/hydrology/prms_soilzone_no_dprst.py
@@ -1,4 +1,5 @@
-from typing import Literal
+import pathlib as pl
+from typing import Literal, Union
 
 from ..base.adapter import adaptable
 from ..base.control import Control
@@ -57,26 +58,31 @@ class PRMSSoilzoneNoDprst(PRMSSoilzone):
             selected then no parameters are adjusted and there will be no
             warnings or errors.
         verbose: Print extra information or not?
-        restart_read: May be boolean or a Pathlib.Path. If False,
-          control.options will be examined for this key. If True, the working
-          directory is searched for restart files. If a Pathlib.Path, this
-          specifies an alternative directory to search for restart files.
-          Files searched for are of the pattern YYYY-mm-dd-varname.nc where the
-          date is the control.init_time. The timestamp on the file is the valid
-          time of the states in the file with the exception of instantaneous
-          variables from the hourly timesteps (e.g. outflow_ts in PRMSChannel,
-          which is valid at the 23rd hour of the timestampped day).
-        restart_write: As for restart_read but for writing. The directory in
-          either case will be attempted to be created if it does not exist.
-        restart_write_freq: The frequency of restart output as "y" for yearly,
-          "m" for monthly, "d" for daily, or "f" for final. "Final" means that
-          restart files are written with the states of control.end_time to
-          files timestampped the following day. Yearly and monthly restart
-          options write files with timestamps on every first day each year or
-          month during the run. If daily, restarts are written every day. If
-          False, control.options will be examined for this key. If
-          restart_write is not False and restart_write_freq is False, the
-          default of "f" is used.
+        restart_read:
+            May be boolean or a Pathlib.Path. If False, control.options
+            will be examined for this key. If True, the working
+            directory is searched for restart files. If a Pathlib.Path, this
+            specifies an alternative directory to search for restart files.
+            Files searched for are of the pattern YYYY-mm-dd-varname.nc where
+            the date is the control.init_time. The timestamp on the file is the
+            valid time of the states in the file with the exception of
+            processes with sub-daily timesteps. For example, the outflow_ts
+            variable of PRMSChannel is instantaneous and valid at the 23rd hour
+            of the timestampped day whereas its variable seg_outflow is the
+            daily averge value over the timestampped day.
+        restart_write:
+            As for restart_read but for writing. The directory in either
+            case will be attempted to be created if it does not exist.
+        restart_write_freq:
+            If False, then control.options is examined for this key. The
+            follwing values set the frequency of restart output with "y" for
+            yearly, "m" for monthly, "d" for daily, or "f" for final. "Final"
+            means that restart files are written with the states at
+            control.end_time to files timestampped with control.end_time.
+            Yearly and monthly restart options write files with timestamps on
+            the last day of each year or month during the run. If daily,
+            restarts are written every day. If restart_write is not False and
+            restart_write_freq is False, the default of "f" is used.
     """
 
     def __init__(
@@ -97,7 +103,10 @@ class PRMSSoilzoneNoDprst(PRMSSoilzone):
         calc_method: Literal["numba", "numpy"] = None,
         adjust_parameters: Literal["warn", "error", "no"] = "warn",
         verbose: bool = None,
-    ) -> "PRMSSoilzone":
+        restart_read: Union[pl.Path, bool] = False,
+        restart_write: Union[pl.Path, bool] = False,
+        restart_write_freq: Literal["y", "m", "d", "f", False] = False,
+    ) -> None:
         self._dprst_flag = False
 
         super().__init__(
@@ -120,6 +129,9 @@ class PRMSSoilzoneNoDprst(PRMSSoilzone):
             calc_method=calc_method,
             adjust_parameters=adjust_parameters,
             verbose=verbose,
+            restart_read=restart_read,
+            restart_write=restart_write,
+            restart_write_freq=restart_write_freq,
         )
 
         self.name = "PRMSSoilzoneNoDprst"


### PR DESCRIPTION
Update/buff restart docs; minor tweaks to restart code and tests: restarts under "y" and "m" now write restart files on the LAST day of the respective periods.
