### PR TITLE
fix PrmsDynamicParameter daily forward-fill at window start

### DIFF
--- a/autotest/conftest.py
+++ b/autotest/conftest.py
@@ -19,8 +19,8 @@ def pytest_addoption(parser):
         default=[],
         help=(
             "Domain(s) to run (name of domain dir and NOT path to it). "
-            "You can pass multiples of this argument. If not used, "
-            "defaults to drb_2yr."
+            "You can pass multiples of this argument. Required for tests "
+            "using the simulation fixture (unless --all_domains is used)."
         ),
     )
 
@@ -148,8 +148,6 @@ def pytest_generate_tests(metafunc):
     if all_domains_option:
         # This is somewhat arbitrary
         domain_list = ["hru_1", "drb_2yr", "ucb_2yr"]
-    elif not all_domains_option and not len(domain_list):
-        domain_list = ["drb_2yr"]
 
     control_pattern_list = metafunc.config.getoption("control_pattern")
 
@@ -157,6 +155,11 @@ def pytest_generate_tests(metafunc):
         return
 
     if "simulation" in metafunc.fixturenames:
+        if not len(domain_list):
+            raise ValueError(
+                "Tests using the simulation fixture require --domain "
+                "(may be repeated) or --all_domains."
+            )
         simulations = collect_simulations(domain_list, control_pattern_list)
 
         # Put --print_ans in the domain fixture as it applies only to the

--- a/autotest/test_prms_dyn_params.py
+++ b/autotest/test_prms_dyn_params.py
@@ -142,6 +142,66 @@ class TestPrmsDynamicParameter:
             # Check data values (exact match for integers)
             np.testing.assert_array_equal(dyn_param.data, expected["data"])
 
+    def test_daily_data_array_forward_fill_mid_window(self):
+        """Forward-fill when daily_start_date falls between file dates.
+
+        The values in effect at daily_start_date come from the most recent
+        file date at or before it, as PRMS applies dynamic updates.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = pl.Path(tmpdir)
+            file_path = tmpdir / "test_int.dyn"
+            expected = self.create_sample_dyn_param_file(
+                file_path, dtype="int"
+            )
+
+            # start between the first (2020-01-15) and second (2020-06-01)
+            # file dates
+            dyn_param = PrmsDynamicParameter.load(file_path, dtype="int")
+            dyn_param.daily_start_date = "2020-03-01"
+            dyn_param.daily_end_date = "2020-06-02"
+            daily = dyn_param.daily_data_array
+
+            assert daily.shape == (94, expected["nhru"])
+            # 2020-03-01 through 2020-05-31 (92 days) forward-fill the
+            # 2020-01-15 values from before the window
+            np.testing.assert_array_equal(
+                daily.values[:92, :],
+                np.tile(expected["data"][0, :], (92, 1)),
+            )
+            # 2020-06-01 and after take the second entry
+            np.testing.assert_array_equal(
+                daily.values[92:, :],
+                np.tile(expected["data"][1, :], (2, 1)),
+            )
+
+    def test_daily_data_array_fill_before_first_date(self):
+        """Days before the first date in the file remain fill values."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = pl.Path(tmpdir)
+            file_path = tmpdir / "test_int.dyn"
+            expected = self.create_sample_dyn_param_file(
+                file_path, dtype="int"
+            )
+
+            # start two days before the first file date (2020-01-15)
+            dyn_param = PrmsDynamicParameter.load(file_path, dtype="int")
+            dyn_param.daily_start_date = "2020-01-13"
+            dyn_param.daily_end_date = "2020-01-16"
+            daily = dyn_param.daily_data_array
+
+            assert daily.shape == (4, expected["nhru"])
+            # 2020-01-13 and 2020-01-14 precede all file dates: fill values
+            np.testing.assert_array_equal(
+                daily.values[:2, :],
+                np.full((2, expected["nhru"]), -999, dtype=np.int32),
+            )
+            # 2020-01-15 and 2020-01-16 take the first entry
+            np.testing.assert_array_equal(
+                daily.values[2:, :],
+                np.tile(expected["data"][0, :], (2, 1)),
+            )
+
     def test_round_trip_float(self):
         """Test reading and writing a float file produces identical results."""
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -118,6 +118,12 @@ Breaking Changes
 
 Bug fixes
 ~~~~~~~~~
+- :class:`utils.PrmsDynamicParameter` ``daily_data_array`` left fill values for days
+  between ``daily_start_date`` and the first dynamic parameter date inside that window,
+  instead of forward-filling from the most recent date at or before ``daily_start_date``
+  as PRMS applies dynamic updates. Only runs starting between dynamic parameter dates
+  were affected.
+  (:pull:`XXX`) By `James McCreight <https://github.com/jmccreight>`_.
 - PRMS 5.2.1.1 had a bug in stream temperature where division by HRU area was repeated
   multiple times. In the old code this occurred in routing.f90 on lines 764 and
   765 and then again on 789 and 790, where ``seginc_swrad`` and ``seginc_potet`` were

--- a/pywatershed/utils/prms_dyn_param.py
+++ b/pywatershed/utils/prms_dyn_param.py
@@ -527,8 +527,18 @@ class PrmsDynamicParameter:
         full_data = np.full((n_days, self.nhru), fill_value, dtype=data_dtype)
 
         # Fill in data where we have it, forward-filling between known dates
-        # First, find which data index applies to each day (forward-fill logic)
+        # First, find which data index applies to each day (forward-fill
+        # logic). Seed with the most recent date at or before start_date so
+        # that days preceding the first in-window date are forward-filled
+        # from earlier data, as PRMS applies the most recent update at or
+        # before the current date.
         current_data_idx = None
+        for idx, date in enumerate(dates_as_datetime):
+            if date <= start_date:
+                current_data_idx = idx
+            else:
+                break
+
         for i, date in enumerate(all_dates):
             if date in date_to_index:
                 # We have data for this date, use it


### PR DESCRIPTION
_build_daily_data left fill values (-999 / f4 fill) for days between daily_start_date and the first dynamic parameter date inside the window. Seed the forward-fill with the most recent file date at or before daily_start_date, matching how PRMS applies dynamic updates (most recent update at or before the current date). Days before the first date in the file still receive fill values.

Add the first direct tests of daily_data_array: a mid-window start that fails without the fix, and a start-before-first-date regression.

Also remove the silent drb_2yr default domain in autotest/conftest.py: tests using the simulation fixture now require explicit --domain (or --all_domains) and error clearly at collection otherwise. CI and ci_local.sh always pass --domain explicitly; the fallback only caused surprising local behavior.

- [X] Tests added
- [X] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

## Docs

Look for this PR number in our [read-the-docs builds](https://app.readthedocs.org/projects/pywatershed/builds/) where you can browse on-line.

You can alternatively get a CI-build of the docs by entering the PR number for the `###` in https://github.com/DOI-USGS/pywatershed/pull/###/checks then clicking on `Documentation Build` and finally looking for the `documentation-html` artifact which will download as a zip file.
