### PR TITLE
remove fortran-lang/setup-fortran from CI, use conda env gfortran

### DIFF
--- a/.github/scripts/symlink_gfortran_mac.sh
+++ b/.github/scripts/symlink_gfortran_mac.sh
@@ -1,22 +1,26 @@
 #!/usr/bin/env bash
 
-# get full gfortran version string
-# assumes installed via brew as by
-# https://github.com/fortran-lang/setup-fortran
+# Symlink gfortran runtime libraries from the active conda environment
+# (gfortran is provided by environment.yml) into /usr/local/lib, which is
+# on dyld's default fallback search path. This lets the prebuilt binaries
+# in bin/ resolve @rpath/libgfortran.5.dylib etc. regardless of the rpaths
+# they were built with.
 #
-# sed not head for first line, avoid ruby broken pipe issues
-# (https://stackoverflow.com/a/2845541/6514033)
-full_version=$(brew info gfortran | sed -n 1p | cut -d' ' -f 4)
+# Requires the micromamba environment to be activated (CONDA_PREFIX set),
+# so this must run after the setup-micromamba step.
 
-# get major version
-version=$(echo "$full_version" | cut -d'.' -f 1)
-
-# symlink gfortran libraries
-old_libdir="/usr/local/opt/gcc/lib/gcc/${version}"
-new_libdir="/usr/local/lib/"
-mkdir -p "$new_libdir"
-if [ -d "$old_libdir" ]
-then
-  sudo ln -fs "$old_libdir/libgfortran.5.dylib" "$new_libdir/libgfortran.5.dylib"
-  sudo ln -fs "$old_libdir/libquadmath.0.dylib" "$new_libdir/libquadmath.0.dylib"
+if [ -z "${CONDA_PREFIX}" ]; then
+    echo "CONDA_PREFIX is not set: activate the conda environment first"
+    exit 1
 fi
+
+new_libdir="/usr/local/lib"
+sudo mkdir -p "$new_libdir"
+for lib in libgfortran.5.dylib libquadmath.0.dylib; do
+    src="${CONDA_PREFIX}/lib/${lib}"
+    if [ ! -f "$src" ]; then
+        echo "Not found: $src"
+        exit 1
+    fi
+    sudo ln -fs "$src" "${new_libdir}/${lib}"
+done

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -142,16 +142,6 @@ jobs:
         uses: mxschmitt/action-tmate@v3
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
 
-      - name: Setup gfortran
-        uses: fortran-lang/setup-fortran@v1
-        with:
-          compiler: gcc
-          version: 11
-
-      - name: Link gfortran dylibs on Mac
-        if: runner.os == 'macOS'
-        run: .github/scripts/symlink_gfortran_mac.sh
-
       - name: Install Dependencies via Micromamba
         uses: mamba-org/setup-micromamba@v3
         with:
@@ -161,6 +151,10 @@ jobs:
           cache-downloads: true
           create-args: >-
             python=${{matrix.python-version}}
+
+      - name: Link conda gfortran dylibs on Mac
+        if: runner.os == 'macOS'
+        run: .github/scripts/symlink_gfortran_mac.sh
 
       - name: Set environment variables
         run: |
@@ -255,16 +249,6 @@ jobs:
         uses: mxschmitt/action-tmate@v3
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
 
-      - name: Setup gfortran
-        uses: fortran-lang/setup-fortran@v1
-        with:
-          compiler: gcc
-          version: 11
-
-      - name: Link gfortran dylibs on Mac
-        if: runner.os == 'macOS'
-        run: .github/scripts/symlink_gfortran_mac.sh
-
       - name: Install Dependencies via Micromamba
         uses: mamba-org/setup-micromamba@v3
         with:
@@ -274,6 +258,10 @@ jobs:
           cache-downloads: true
           create-args: >-
             python=${{matrix.python-version}}
+
+      - name: Link conda gfortran dylibs on Mac
+        if: runner.os == 'macOS'
+        run: .github/scripts/symlink_gfortran_mac.sh
 
       - name: Install pywatershed
         run: |
@@ -375,16 +363,6 @@ jobs:
         uses: mxschmitt/action-tmate@v3
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
 
-      - name: Setup gfortran
-        uses: fortran-lang/setup-fortran@v1
-        with:
-          compiler: gcc
-          version: 11
-
-      - name: Link gfortran dylibs on Mac
-        if: runner.os == 'macOS'
-        run: .github/scripts/symlink_gfortran_mac.sh
-
       - name: Install Dependencies via Micromamba
         uses: mamba-org/setup-micromamba@v3
         with:
@@ -394,6 +372,10 @@ jobs:
           cache-downloads: true
           create-args: >-
             python=${{matrix.python-version}}
+
+      - name: Link conda gfortran dylibs on Mac
+        if: runner.os == 'macOS'
+        run: .github/scripts/symlink_gfortran_mac.sh
 
       - name: Install pywatershed
         run: |
@@ -513,16 +495,6 @@ jobs:
           echo "PYTHON_VERSION=${{ matrix.python-version }}" >> $GITHUB_ENV
           cat .mf6_ci_ref_remote  >> $GITHUB_ENV
 
-      - name: Setup gfortran
-        uses: fortran-lang/setup-fortran@v1
-        with:
-          compiler: gcc
-          version: 11
-
-      - name: Link gfortran dylibs on Mac
-        if: runner.os == 'macOS'
-        run: .github/scripts/symlink_gfortran_mac.sh
-
       - name: Install Dependencies via Micromamba
         uses: mamba-org/setup-micromamba@v3
         with:
@@ -532,6 +504,10 @@ jobs:
           cache-downloads: true
           create-args: >-
             python=${{matrix.python-version}}
+
+      - name: Link conda gfortran dylibs on Mac
+        if: runner.os == 'macOS'
+        run: .github/scripts/symlink_gfortran_mac.sh
 
       - name: Enforce MF6 ref and remote merge to main
         # need the code to update flopy but can get the binary
@@ -763,16 +739,6 @@ jobs:
           echo $MF6_REMOTE
           if [[ "$MF6_REMOTE" != "$req_remote" ]]; then echo "bad mf6 remote in .mf6_ci_ref_remote"; exit 1; fi
 
-      - name: Setup gfortran
-        uses: fortran-lang/setup-fortran@v1
-        with:
-          compiler: gcc
-          version: 11
-
-      - name: Link gfortran dylibs on Mac
-        if: runner.os == 'macOS'
-        run: .github/scripts/symlink_gfortran_mac.sh
-
       - name: Install Dependencies via Micromamba
         uses: mamba-org/setup-micromamba@v3
         with:
@@ -782,6 +748,10 @@ jobs:
           cache-downloads: true
           create-args: >-
             python=${{matrix.python-version}}
+
+      - name: Link conda gfortran dylibs on Mac
+        if: runner.os == 'macOS'
+        run: .github/scripts/symlink_gfortran_mac.sh
 
       - name: Install pywatershed
         run: |
@@ -874,16 +844,6 @@ jobs:
         uses: mxschmitt/action-tmate@v3
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
 
-      - name: Setup gfortran
-        uses: fortran-lang/setup-fortran@v1
-        with:
-          compiler: gcc
-          version: 11
-
-      - name: Link gfortran dylibs on Mac
-        if: runner.os == 'macOS'
-        run: .github/scripts/symlink_gfortran_mac.sh
-
       - name: Install Dependencies via Micromamba
         uses: mamba-org/setup-micromamba@v3
         with:
@@ -893,6 +853,10 @@ jobs:
           cache-downloads: true
           create-args: >-
             python=${{matrix.python-version}}
+
+      - name: Link conda gfortran dylibs on Mac
+        if: runner.os == 'macOS'
+        run: .github/scripts/symlink_gfortran_mac.sh
 
       - name: Install pywatershed
         run: |
@@ -990,16 +954,6 @@ jobs:
         uses: mxschmitt/action-tmate@v3
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
 
-      - name: Setup gfortran
-        uses: fortran-lang/setup-fortran@v1
-        with:
-          compiler: gcc
-          version: 11
-
-      - name: Link gfortran dylibs on Mac
-        if: runner.os == 'macOS'
-        run: .github/scripts/symlink_gfortran_mac.sh
-
       - name: Install Dependencies via Micromamba
         uses: mamba-org/setup-micromamba@v3
         with:
@@ -1009,6 +963,10 @@ jobs:
           cache-downloads: true
           create-args: >-
             python=${{matrix.python-version}}
+
+      - name: Link conda gfortran dylibs on Mac
+        if: runner.os == 'macOS'
+        run: .github/scripts/symlink_gfortran_mac.sh
 
       - name: Install pywatershed
         run: |
@@ -1167,16 +1125,6 @@ jobs:
         uses: mxschmitt/action-tmate@v3
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
 
-      - name: Setup gfortran
-        uses: fortran-lang/setup-fortran@v1
-        with:
-          compiler: gcc
-          version: 11
-
-      - name: Link gfortran dylibs on Mac
-        if: runner.os == 'macOS'
-        run: .github/scripts/symlink_gfortran_mac.sh
-
       - name: Install Dependencies via Micromamba
         uses: mamba-org/setup-micromamba@v3
         with:
@@ -1186,6 +1134,10 @@ jobs:
           cache-downloads: true
           create-args: >-
             python=${{matrix.python-version}}
+
+      - name: Link conda gfortran dylibs on Mac
+        if: runner.os == 'macOS'
+        run: .github/scripts/symlink_gfortran_mac.sh
 
       - name: Install pywatershed
         run: |

--- a/.github/workflows/ci_examples.yaml
+++ b/.github/workflows/ci_examples.yaml
@@ -34,12 +34,6 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v6
 
-      - name: Setup gfortran
-        uses: fortran-lang/setup-fortran@v1
-        with:
-          compiler: gcc
-          version: 11
-
       - name: Setup micromamba
         uses: mamba-org/setup-micromamba@v3
         with:


### PR DESCRIPTION
environment.yml already provides gfortran>=15.2.0 via conda-forge, which is what compiles PRMS 5.2.1.1 in the drb job (whatever gfortran is on PATH) and what the committed apple-silicon PRMS binary was built against.

The one real coupling was on macOS: the prebuilt PRMS binary links @rpath/libgfortran.5.dylib with rpaths that only resolve on the build machine, so dyld falls back to /usr/local/lib where symlink_gfortran_mac.sh plants the libs. That script sourced them from setup-fortran's brew gcc; repoint it at the active conda environment ($CONDA_PREFIX/lib) and run it after the micromamba step instead of before.

ci_examples.yaml still uses setup-fortran; treat separately if this proves out.

<!-- START doctoc generated TOC please keep comment here to allow auto update -->
<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*

- [Docs](#docs)

<!-- END doctoc generated TOC please keep comment here to allow auto update -->

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Performance benchmarks added
- [ ] Performance regression benchmarks run
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst` or it's sub rsts?

## Docs

Look for this PR number in our [read-the-docs builds](https://app.readthedocs.org/projects/pywatershed/builds/) where you can browse on-line.

You can alternatively get a CI-build of the docs by entering the PR number for the `###` in https://github.com/DOI-USGS/pywatershed/pull/###/checks then clicking on `Documentation Build` and finally looking for the `documentation-html` artifact which will download as a zip file.
