### PR TITLE
Model.solve_inputs: input wiring from classes, without instantiation

### DIFF
--- a/autotest/test_model_solve_inputs.py
+++ b/autotest/test_model_solve_inputs.py
@@ -1,0 +1,100 @@
+import pytest
+
+import pywatershed as pws
+
+NHM_PROCESSES = [
+    pws.PRMSSolarGeometry,
+    pws.PRMSAtmosphere,
+    pws.PRMSCanopy,
+    pws.PRMSSnow,
+    pws.PRMSRunoff,
+    pws.PRMSSoilzone,
+    pws.PRMSGroundwater,
+    pws.PRMSChannel,
+]
+
+
+@pytest.mark.domainless
+def test_solve_inputs_nhm_process_list():
+    """The full NHM: only the forcings come from file."""
+    result = pws.Model.solve_inputs(NHM_PROCESSES)
+
+    assert result["from_file"] == ["prcp", "tmax", "tmin"]
+
+    inputs_from = result["inputs_from"]
+    # spot-check process-to-process wiring
+    assert inputs_from["PRMSAtmosphere"]["soltab_potsw"] == (
+        "PRMSSolarGeometry"
+    )
+    assert inputs_from["PRMSAtmosphere"]["prcp"] is None
+    assert inputs_from["PRMSSnow"]["net_ppt"] == "PRMSCanopy"
+    assert inputs_from["PRMSChannel"]["sroff_vol"] == "PRMSRunoff"
+    assert inputs_from["PRMSChannel"]["gwres_flow_vol"] == "PRMSGroundwater"
+    # a process with no inputs has an empty entry
+    assert inputs_from["PRMSSolarGeometry"] == {}
+
+
+@pytest.mark.domainless
+def test_solve_inputs_below_snow_subset():
+    """A truncated model: everything the missing processes supplied is
+    needed from file (e.g. forcing a sub-model from another model's
+    output)."""
+    subset = [
+        pws.PRMSRunoffAg,
+        pws.PRMSSoilzoneAg,
+        pws.PRMSGroundwater,
+        pws.PRMSChannel,
+    ]
+    result = pws.Model.solve_inputs(subset)
+
+    # atmosphere/canopy/snow-supplied inputs are now file inputs
+    for input_name in [
+        "potet",
+        "transp_on",
+        "net_ppt",
+        "net_rain",
+        "net_snow",
+        "snowmelt",
+        "snowcov_area",
+        "snow_evap",
+        "hru_intcpevap",
+    ]:
+        assert input_name in result["from_file"]
+
+    # within-subset wiring is unaffected
+    inputs_from = result["inputs_from"]
+    assert inputs_from["PRMSSoilzoneAg"]["infil_ag"] == "PRMSRunoffAg"
+    assert inputs_from["PRMSChannel"]["sroff_vol"] == "PRMSRunoffAg"
+
+
+@pytest.mark.domainless
+def test_solve_inputs_model_dict_passed_inputs():
+    """Dict form: a spec key naming an input in the class's __init__
+    signature counts as passed and drops out of the wiring; non-process
+    entries are ignored."""
+    model_dict = {
+        "control": "not a process spec",
+        "dis_hru": "not a process spec",
+        "runoff": {"class": pws.PRMSRunoffAg},
+        "soilzone": {"class": pws.PRMSSoilzoneAg, "ag_frac": "a value"},
+    }
+    result = pws.Model.solve_inputs(model_dict)
+
+    assert set(result["inputs_from"].keys()) == {"runoff", "soilzone"}
+    # passed for soilzone: omitted from its wiring...
+    assert "ag_frac" not in result["inputs_from"]["soilzone"]
+    # ...but runoff also consumes ag_frac and was not passed it, so it
+    # remains a file input (passing is per process spec, not global)
+    assert result["inputs_from"]["runoff"]["ag_frac"] is None
+    assert "ag_frac" in result["from_file"]
+
+    # with only the passed consumer present, it drops out entirely
+    del model_dict["runoff"]
+    result = pws.Model.solve_inputs(model_dict)
+    assert "ag_frac" not in result["from_file"]
+
+    # and without passing it, it is a file input
+    model_dict["soilzone"] = {"class": pws.PRMSSoilzoneAg}
+    result = pws.Model.solve_inputs(model_dict)
+    assert result["inputs_from"]["soilzone"]["ag_frac"] is None
+    assert "ag_frac" in result["from_file"]

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -16,6 +16,13 @@ v3.0.0 (Unreleased)
 
 New Features
 ~~~~~~~~~~~~~~~~
+- The new staticmethod :meth:`Model.solve_inputs` determines where each process
+  input comes from — another process or a file — from a process list or model
+  dictionary, without instantiating a Model or requiring any files to exist.
+  Useful for determining the file inputs a model configuration requires, e.g.
+  when forcing a sub-model from another model's outputs. Model construction
+  uses the same implementation internally.
+  (:pull:`XXX`) By `James McCreight <https://github.com/jmccreight>`_.
 - The :class:`base.ConservativeProcess` class now supports both mass and energy budgets.
   Processes can specify which quantity to budget using the ``quantity`` parameter in
   ``_set_budget()``. The new ``mass_budget`` and ``energy_budget`` properties provide

--- a/pywatershed/base/model.py
+++ b/pywatershed/base/model.py
@@ -1,5 +1,4 @@
 import pathlib as pl
-from copy import deepcopy
 from datetime import datetime
 from typing import Type, Union
 
@@ -444,78 +443,139 @@ class Model:
 
         return
 
-    def _solve_inputs(self):
-        """What processes supply inputs to others, what files are needed?
+    @staticmethod
+    def solve_inputs(process_list_or_model_dict) -> dict:
+        """Determine where each process input comes from, per class.
 
-        TODO: this does not currently take order into account, which could
-              be important and is now possible with order specified.
-        """
+        Answers, without instantiating a Model (or requiring any files to
+        exist): which inputs are supplied by other processes and which
+        must come from file. All information required is class-level.
+
+        Args:
+            process_list_or_model_dict: as for Model. Either a list of
+                Process classes, or a model dictionary whose process
+                specifications are dicts with a "class" key (non-dict and
+                class-less entries, e.g. control or discretizations, are
+                ignored). In the dictionary form, a specification key
+                naming an input that is also in the class's ``__init__``
+                signature counts as a passed input, satisfied by the
+                specification itself (e.g. ``ag_frac``).
+
+        Returns:
+            A dict with keys:
+
+            - ``"inputs_from"``: ``{process_name: {input_name: source}}``
+              where source is the producing process's name, or None if
+              the input must come from file. Passed inputs are omitted.
+            - ``"from_file"``: sorted list of the input names that must
+              come from file (the union of the None-sourced inputs).
+
+        Notes:
+            - Process order is not considered (matching Model
+              construction; a later process can supply an earlier one).
+            - input_aliases are not considered; names are variable names.
+
+        Examples:
+            >>> import pywatershed as pws
+            >>> below_soil = [pws.PRMSGroundwater, pws.PRMSChannel]
+            >>> pws.Model.solve_inputs(below_soil)["from_file"]
+            ['dprst_seep_hru', 'soil_to_gw', 'sroff_vol', 'ssr_to_gw', 'ssres_flow_vol']
+        """  # noqa: E501
         import inspect
 
-        proc_dict = {
-            proc_name: self.model_dict[proc_name]["class"]
-            for proc_name in self._category_key_dict["process"]
-        }
+        if isinstance(process_list_or_model_dict, (list, tuple)):
+            specs = {
+                cls.__name__: {"class": cls}
+                for cls in process_list_or_model_dict
+            }
+        else:
+            specs = {
+                kk: vv
+                for kk, vv in process_list_or_model_dict.items()
+                if isinstance(vv, dict) and "class" in vv.keys()
+            }
 
+        proc_dict = {kk: vv["class"] for kk, vv in specs.items()}
         proc_inputs = {kk: vv.get_inputs() for kk, vv in proc_dict.items()}
         proc_vars = {kk: vv.get_variables() for kk, vv in proc_dict.items()}
 
         def get_passed_args(
             proc_class: Type, proc_passed_arg_names: list
-        ) -> list:
+        ) -> set:
             signature_args = set(
                 inspect.signature(proc_class.__init__).parameters.keys()
             )
-            passed_args = (
+            return (
                 signature_args
                 & set(proc_passed_arg_names)
                 & set(proc_class.get_inputs())
             )
-            return list(passed_args)
 
         proc_passed_inputs = {
-            proc_name: get_passed_args(
-                proc_dict[proc_name], self.model_dict[proc_name].keys()
-            )
-            for proc_name in self._category_key_dict["process"]
+            kk: get_passed_args(proc_dict[kk], specs[kk].keys())
+            for kk in proc_dict.keys()
         }
 
         # Solve where inputs come from
         inputs_from = {}
         for comp in proc_dict.keys():
-            inputs = deepcopy(proc_inputs)
-            vars = deepcopy(proc_vars)
-            c_inputs = inputs.pop(comp)
-            _ = vars.pop(comp)
-
             inputs_from[comp] = {}
-            for input in c_inputs:
-                inputs_ptr = inputs_from
+            for input in proc_inputs[comp]:
                 if input in proc_passed_inputs[comp]:
                     continue
-                inputs_ptr[comp][input] = []  # could use None
-                for other in inputs.keys():
-                    if input in vars[other]:
-                        inputs_ptr[comp][input] += [other]
-                        # this should be a list of length one
-                        # check?
+                producers = [
+                    other
+                    for other in proc_dict.keys()
+                    if other != comp and input in proc_vars[other]
+                ]
+                # generally zero or one producer; the first is used
+                inputs_from[comp][input] = producers[0] if producers else None
+
+        from_file = sorted(
+            {
+                input
+                for wired in inputs_from.values()
+                for input, source in wired.items()
+                if source is None
+            }
+        )
+
+        return {"inputs_from": inputs_from, "from_file": from_file}
+
+    def _solve_inputs(self):
+        """What processes supply inputs to others, what files are needed?
+
+        The pure logic lives in the public staticmethod solve_inputs;
+        here its answer is adapted to the internal representations.
+
+        TODO: this does not currently take order into account, which could
+              be important and is now possible with order specified.
+        """
+        specs = {
+            proc_name: self.model_dict[proc_name]
+            for proc_name in self._category_key_dict["process"]
+        }
+        solved = Model.solve_inputs(specs)
+
+        # internal representation: source as a list, empty if from file
+        inputs_from = {
+            comp: {
+                input: [] if source is None else [source]
+                for input, source in wired.items()
+            }
+            for comp, wired in solved["inputs_from"].items()
+        }
 
         # If inputs dont come from other processes or self, assume they come
         # from file in input_dir or input_file. Exception is that
         # PRMSAtmosphere requires its files on init, so dont adapt these
-        input_names = set([])
-        for k0, v0 in inputs_from.items():
-            for k1, v1 in v0.items():
-                if not v1:
-                    input_names = input_names.union([k1])
+        input_names = set(solved["from_file"])
 
         # initiate the file inputs here rather than in the processes
-        file_inputs = {}
         # Use dummy names for now
-        for name in input_names:
-            file_inputs[name] = pl.Path(name)
+        file_inputs = {name: pl.Path(name) for name in input_names}
 
-        self._proc_dict = proc_dict
+        self._proc_dict = {kk: vv["class"] for kk, vv in specs.items()}
         self._inputs_from = inputs_from
         self._input_names = input_names
         self._file_inputs = file_inputs


### PR DESCRIPTION
Extract the pure logic of Model._solve_inputs into a public staticmethod taking a process list or model dictionary (as Model.__init__ does) and returning which inputs come from other processes and which must come from file. All required information is class-level, so no control, parameters, or files are needed. Model construction delegates to the same implementation, so the two cannot drift. Useful for determining the file inputs a model configuration requires, e.g. when forcing a sub-model from another model's outputs.

Domainless tests cover the full-NHM wiring, a truncated below-snow process set, and dict-form passed inputs (which are per process spec: an input passed to one process remains a file input for another unpassed consumer).

<!-- START doctoc generated TOC please keep comment here to allow auto update -->
<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*

- [Docs](#docs)

<!-- END doctoc generated TOC please keep comment here to allow auto update -->

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Performance benchmarks added
- [ ] Performance regression benchmarks run
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst` or it's sub rsts?

## Docs

Look for this PR number in our [read-the-docs builds](https://app.readthedocs.org/projects/pywatershed/builds/) where you can browse on-line.

You can alternatively get a CI-build of the docs by entering the PR number for the `###` in https://github.com/DOI-USGS/pywatershed/pull/###/checks then clicking on `Documentation Build` and finally looking for the `documentation-html` artifact which will download as a zip file.
