### PR TITLE
Require pyPRMS>=0.10.0, unpinning packaging; remove calls to pyPRMS deprecations

### DIFF
--- a/autotest/test_obsin_flow_node.py
+++ b/autotest/test_obsin_flow_node.py
@@ -73,13 +73,14 @@ def test_prms_channel_obsin_compare_prms(
     # Constructed using obsout_segment to get the indices and poi ids,
     # we will insert the new nodes below this segment.
     obsout_seg = control_parameters.parameters["obsout_segment"] - 1
-    sf_data = PRMSStreamflowData(
-        simulation["dir"] / "sf_data",
-        metadata=pyprms_meta,
-    ).data_by_variable("runoff")
-    old_names = sf_data.columns.tolist()
-    new_names = [cc.split("_")[1] for cc in sf_data.columns.tolist()]
-    sf_data.rename(columns=dict(zip(old_names, new_names)), inplace=True)
+    sf_data = (
+        PRMSStreamflowData(
+            simulation["dir"] / "sf_data",
+            metadata=pyprms_meta,
+        )
+        .get("runoff")
+        .data.copy()
+    )
 
     poi_inds = obsout_seg[np.where(obsout_seg >= 0)].tolist()
     npoi = len(poi_inds)

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -27,6 +27,12 @@ Bug fixes
 
 Internal changes
 ~~~~~~~~~~~~~~~~
+- Require pyPRMS >=0.10.0 and remove the temporary ``packaging <26.3`` pin it
+  supersedes (pyPRMS 0.9.10 crashed on import of metadata with packaging >=26.3).
+  Also remove calls to pyPRMS methods deprecated in 0.10.0:
+  ``Parameters.adjust_bounded_parameters()`` in domain subsetting and
+  ``DataFile.data_by_variable()`` in the obsin flow node test.
+  (:pull:`406`) By `James McCreight <https://github.com/jmccreight>`_.
 
 .. _whats-new.3.0.0:
 

--- a/environment.yml
+++ b/environment.yml
@@ -23,11 +23,6 @@ dependencies:
   - networkx
   - numpy>=2.0.0
   - numba
-  # TEMPORARY: pyPRMS 0.9.10 MetaData crashes with packaging >=26.3
-  # (Version(None) now raises InvalidVersion, escaping its
-  # except TypeError). Remove when a fixed pyPRMS releases and
-  # require that pyPRMS version instead.
-  - packaging<26.3
   - pandas>=1.4.0
   - pint
   - pip
@@ -55,7 +50,7 @@ dependencies:
   - zarr
   - pip:
       - git+https://github.com/jararias/mpsplines.git
-      - pyPRMS
+      - pyPRMS>=0.10.0
       - modflow-devtools[dfn]==1.7.0
       - pytest-error-for-skips
       - "flopy[codegen] @ git+https://github.com/modflowpy/flopy.git"

--- a/environment_w_jupyter.yml
+++ b/environment_w_jupyter.yml
@@ -29,11 +29,6 @@ dependencies:
   - networkx
   - numpy>=2.0.0
   - numba
-  # TEMPORARY: pyPRMS 0.9.10 MetaData crashes with packaging >=26.3
-  # (Version(None) now raises InvalidVersion, escaping its
-  # except TypeError). Remove when a fixed pyPRMS releases and
-  # require that pyPRMS version instead.
-  - packaging<26.3
   - pandas>=1.4.0
   - pint
   - pip
@@ -61,7 +56,7 @@ dependencies:
   - zarr
   - pip:
       - git+https://github.com/jararias/mpsplines.git
-      - pyPRMS
+      - pyPRMS>=0.10.0
       - modflow-devtools[dfn]==1.7.0
       - pytest-error-for-skips
       - "flopy[codegen] @ git+https://github.com/modflowpy/flopy.git"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,10 +35,7 @@ dependencies = [
     "numba",
     "pandas >= 1.4.0",
     "pint",
-    "pyPRMS",
-    # TEMPORARY: pyPRMS 0.9.10 MetaData crashes with packaging >=26.3;
-    # replace with a pyPRMS version floor when its fix releases
-    "packaging <26.3",
+    "pyPRMS >=0.10.0",
     "pyyaml",
     "tqdm",
     "xarray >= 2023.5.0",

--- a/pywatershed/utils/domain_subset.py
+++ b/pywatershed/utils/domain_subset.py
@@ -1011,8 +1011,6 @@ class DomainSubset:
             # Add the data
             pp_params.get(str(var)).data = cparam.values
 
-        pp_params.adjust_bounded_parameters()
-
         file_name = pl.Path(self._sub_control["param_file"].values).name
         self._sub_control["param_file"].values = file_name
         pp_params.write_parameter_file(filename=write_dir / file_name)


### PR DESCRIPTION
## Summary

Swaps the TEMPORARY packaging <26.3 pin — the workaround for pyPRMS 0.9.10's
MetaData crashing under packaging >=26.3 — for a pyPRMS>=0.10.0 floor in
pyproject.toml, environment.yml, and environment_w_jupyter.yml.

Also removes calls to methods deprecated in pyPRMS 0.10.0:

Parameters.adjust_bounded_parameters() in domain_subset.py (bounded
  parameters now resolve at add() time in pyPRMS)
DataFile.data_by_variable() in test_obsin_flow_node.py (replaced with
  .get("runoff").data, which also made the column renaming unnecessary)

## Timing

**Do not merge until pyPRMS 0.10.0 is on PyPI** — pip cannot resolve the new
floor before then, so CI stays red. This PR doubles as the downstream
integration sign-off for that release.

## Testing

Verified locally against pyPRMS DOI-USGS/development tip (0.10.0) with
packaging 26.3:

domainless: 37 passed
test_domain_subset.py --domain ucb_2yr: 6 passed
test_obsin_flow_node.py --domain drb_2yr: 1 passed

The latter two ran with -W error::DeprecationWarning, confirming no pyPRMS
deprecations remain on these paths.

## Checklist

[x] User visible changes (including notable bug fixes) are documented in
      whats-new.rst (update the :pull: number if it isn't #404)

## Docs

Look for this PR number in our
[read-the-docs builds](https://app.readthedocs.org/projects/pywatershed/builds/)
where you can browse on-line.