### PR TITLE
Add MAINTENANCE.md ledger and /maintenance skill

### DIFF
--- a/.claude/skills/ci-triage/SKILL.md
+++ b/.claude/skills/ci-triage/SKILL.md
@@ -6,9 +6,12 @@ description: Triage failing GitHub Actions runs on pywatershed PRs or branches u
 # Triaging pywatershed CI failures
 
 You diagnose; the human clicks. You run read-only API queries (curl,
-no auth) and local reproductions; the human re-runs workflows, pushes
-fixes, and merges. Unauthenticated API calls are limited to 60/hour
-per IP — batch queries and cache responses to /tmp files.
+no auth); the human re-runs workflows, pushes fixes, and merges.
+Local reproduction (section 5) runs code and modifies the local
+environment (deletes/reinstalls binaries, regenerates test data) —
+propose those steps and get explicit permission before running any of
+them. Unauthenticated API calls are limited to 60/hour per IP — batch
+queries and cache responses to /tmp files.
 
 ## 1. Identify the target
 

--- a/.claude/skills/maintenance/SKILL.md
+++ b/.claude/skills/maintenance/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: maintenance
+description: Walk the repo's MAINTENANCE.md ledger of cross-repo and externally-blocked todos, check each item's blocked-on condition live via public APIs, and report what is actionable now. Use when the user invokes /maintenance or asks about maintenance status, loose ends, or whether something is unblocked.
+---
+
+# Working the maintenance ledger
+
+`MAINTENANCE.md` at the repo root is the source of truth: a list of
+maintenance items, each with a **Blocked on** condition (stated so it
+can be checked mechanically) and an **Action** for when it unblocks.
+Read it fully first.
+
+## Ground rules
+
+- You run read-only checks (curl against public APIs, local greps) and
+  edit `MAINTENANCE.md`; the human runs all git commands and clicks
+  (re-runs, merges, PR creation). Draft paste-ready commands.
+- Unauthenticated GitHub API: 60 requests/hour per IP. Batch, cache to
+  /tmp, and prefer one query that answers several items.
+- The ledger is repo-tracked: after updating it (item status, moves to
+  Done with a date), hand the human a commit. New items discovered in
+  conversation get added with a checkable blocked-on condition.
+
+## Procedure
+
+1. Read `MAINTENANCE.md`.
+2. For each Open item, evaluate its blocked-on condition live (recipes
+   below). Classify: **actionable now**, **still blocked** (say what
+   you observed), or **already done** (evidence found — move to Done).
+3. Report a short table: item / verdict / evidence. Lead with the
+   actionable items and draft their commands.
+4. Update `MAINTENANCE.md` to match reality; hand over the commit.
+
+## Check recipes
+
+- PyPI latest + release dates:
+  `curl -s https://pypi.org/pypi/<pkg>/json` →
+  `info.version`, `releases[<v>][0].upload_time`.
+- conda-forge package versions:
+  `curl -s https://api.anaconda.org/package/conda-forge/<pkg>` →
+  `versions`.
+- GitHub PR state:
+  `curl -s https://api.github.com/repos/<owner>/<repo>/pulls/<n>` →
+  `state`, `merged_at`; open PRs:
+  `.../pulls?state=open`.
+- GitHub releases/tags:
+  `curl -s https://api.github.com/repos/<owner>/<repo>/releases/latest`.
+- Whether a commit/PR is in a release: compare the release tag date to
+  the PR `merged_at`, or
+  `.../compare/<tag>...<sha>` → `status` (`behind` means included).
+- A deployed GitHub Pages site: `curl -sI https://<site>/<path>` (200
+  vs 404) — sufficient to check publication without a browser.
+- CI state on a sha:
+  `.../commits/<sha>/check-runs?per_page=100` (see the `/ci-triage`
+  skill for interpreting results).
+
+## Related repos this ledger spans
+
+- `DOI-USGS/pywatershed` (this repo) and James's fork `jmccreight/...`
+- `DOI-USGS/pyPRMS` (upstream dependency; local clone `~/usgs/pyPRMS`)
+- `conda-forge/pywatershed-feedstock` and `conda-forge/pyprms-feedstock`
+  (local clones `~/usgs/pywatershed-feedstock`, `~/usgs/pyPRMS-feedstock`)
+- `modflowpy/flopy` (dependency whose release gates the 3.0.1 hotfix)

--- a/.claude/skills/maintenance/SKILL.md
+++ b/.claude/skills/maintenance/SKILL.md
@@ -15,6 +15,12 @@ Read it fully first.
 - You run read-only checks (curl against public APIs, local greps) and
   edit `MAINTENANCE.md`; the human runs all git commands and clicks
   (re-runs, merges, PR creation). Draft paste-ready commands.
+- Read-only git (`status`, `log`, `branch`, `remote`, `diff`) in this
+  repo and the related clones listed below is fine. Anything that
+  creates, mutates, or destroys state — commits, pushes, PRs,
+  comments, or running project code — requires asking the human AND
+  receiving explicit permission first; drafting a command is not
+  permission to run it.
 - Unauthenticated GitHub API: 60 requests/hour per IP. Batch, cache to
   /tmp, and prefer one query that answers several items.
 - The ledger is repo-tracked: after updating it (item status, moves to

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -18,6 +18,10 @@ automation it describes).
   explain what each will do before handing it over.
 - You run read-only verifications yourself (file greps, the preflight
   script, HTTP checks of PyPI and GitHub) and report results.
+- Anything not explicitly yours above — in particular anything that
+  creates, mutates, or destroys git state, or publishes — requires
+  asking the human AND receiving explicit permission first; a drafted
+  command is only ever executed by the human.
 - Releases are irreversible at two points — merging to `main` and
   publishing the release (PyPI versions can never be re-uploaded).
   Before each, explicitly confirm the checks passed and the human is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,10 @@ reimplementation of PRMS process representations (see README.md).
   `(:pull:`XXX`)` as the placeholder until the PR number exists.
 - New public classes are exported in `pywatershed/__init__.py` (and the
   subpackage `__init__.py`) and listed in `doc/api/*.rst`.
+- When drafting a PR body, read `.github/PULL_REQUEST_TEMPLATE.md`
+  (fresh each time — it evolves) and conform to it: summary on top,
+  then its checklist with irrelevant items removed and applicable ones
+  checked, keeping its Docs section.
 
 ## Branches and releases
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,10 @@ skills:
 - `/ci-triage` — triages failing GitHub Actions runs on a PR or branch
   via the public API: stale-run vs real-failure verdict, annotations
   when logs are locked, known failure signatures, local repro steps.
+- `/maintenance` — walks the `MAINTENANCE.md` ledger (repo root) of
+  externally-blocked and cross-repo todos, checks each blocked-on
+  condition live (PyPI, conda-forge, GitHub APIs), reports what is
+  actionable, and updates the ledger.
 
 Claude: in your first reply of a session, briefly show the user this
 bullet list of available skills (many users don't know skills exist).

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -17,6 +17,7 @@ and example notebooks.
     - [Installing `pywatershed` in development mode](#installing-pywatershed-in-development-mode)
     - [F2PY](#f2py)
 - [Branching model](#branching-model)
+- [Maintenance ledger](#maintenance-ledger)
 - [CI](#ci)
 - [Testing](#testing)
 - [Linting](#linting)
@@ -131,6 +132,14 @@ occurs on the `develop` branch, while `main` is reserved for the state of the
 latest release. Development PRs are typically squashed to `develop`, to avoid
 merge commits. At release time, release branches are merged to `main`, and then
 `main` is merged back into `develop`.
+
+
+## Maintenance ledger
+Maintenance todos that are blocked on external events (dependency
+releases, cross-repo work like conda-forge feedstocks) are tracked in
+[`MAINTENANCE.md`](MAINTENANCE.md) at the repo root, with mechanically
+checkable unblock conditions. The `/maintenance` Claude skill checks
+them live and reports what is actionable.
 
 
 ## CI

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -5,7 +5,6 @@
   - [Open](#open)
     - [3.0.1 hotfix release (flopy pin unwind + pyPRMS floor)](#301-hotfix-release-flopy-pin-unwind--pyprms-floor)
     - [conda-forge feedstock: pyprms floor replaces packaging pin](#conda-forge-feedstock-pyprms-floor-replaces-packaging-pin)
-    - [PR #407 (cascades port): gate the new sagehen CI jobs](#pr-407-cascades-port-gate-the-new-sagehen-ci-jobs)
     - [pyPRMS upstream: close PR #64, port its regression test](#pyprms-upstream-close-pr-64-port-its-regression-test)
     - [Publish gh-pages v3.0.0 extended release notes upstream](#publish-gh-pages-v300-extended-release-notes-upstream)
     - [Reconcile check_version.yaml with release_preflight.sh](#reconcile-check_versionyaml-with-release_preflightsh)
@@ -64,16 +63,6 @@ check it), **Action** (what to do once unblocked), and optional
   comment `@conda-forge-admin, please rerender`, merge on green. This is
   the last `packaging <26.3` pin anywhere.
 
-### PR #407 (cascades port): gate the new sagehen CI jobs
-
-- **Blocked on:** merging `develop` (with the skeleton/full CI gates,
-  PR #408) into the `feat_cascades_port` branch. Check: PR #407 state and
-  whether its `ci.yaml` sagehen jobs carry `if:` gates.
-- **Action:** paste the domain-job `if:` gate (copy from any gated job in
-  `ci.yaml`) into each new sagehen job with token `ci-sagehen`; then test
-  with a push whose head commit message contains `ci-sagehen`. See
-  DEVELOPER.md under "CI".
-
 ### pyPRMS upstream: close PR #64, port its regression test
 
 - **Blocked on:** coordination with pyPRMS maintainer (pnorton-usgs).
@@ -117,6 +106,9 @@ check it), **Action** (what to do once unblocked), and optional
 
 ## Done
 
+- 2026-08-19: PR #407's new sagehen CI jobs carry the skeleton/full
+  `if:` gates (token `ci-sagehen`); its remaining ubuntu CI failure is
+  being handled on the branch.
 - 2026-08-18: PR #406 (pyPRMS>=0.10.0 floor replaces packaging<26.3 in
   pyproject + both env files) and PR #408 (CI skeleton/full split,
   ci-tokens, concurrency cancellation) merged to develop.

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -6,7 +6,6 @@
     - [3.0.1 hotfix release (flopy pin unwind + pyPRMS floor)](#301-hotfix-release-flopy-pin-unwind--pyprms-floor)
     - [conda-forge feedstock: pyprms floor replaces packaging pin](#conda-forge-feedstock-pyprms-floor-replaces-packaging-pin)
     - [pyPRMS upstream: close PR #64, port its regression test](#pyprms-upstream-close-pr-64-port-its-regression-test)
-    - [Publish gh-pages v3.0.0 extended release notes upstream](#publish-gh-pages-v300-extended-release-notes-upstream)
     - [Reconcile check_version.yaml with release_preflight.sh](#reconcile-check_versionyaml-with-release_preflightsh)
     - [Deliver CI-usage findings to org admins](#deliver-ci-usage-findings-to-org-admins)
   - [Done](#done)
@@ -57,32 +56,21 @@ check it), **Action** (what to do once unblocked), and optional
 - **Blocked on:** nothing (pyprms 0.10.0 reached conda-forge 2026-08-18).
   Check: `https://api.anaconda.org/package/conda-forge/pyprms` versions,
   and PRs at `conda-forge/pywatershed-feedstock`.
-- **Action:** the edit exists in a local clone
-  (`recipe/meta.yaml`: `pyprms >=0.10.0` replacing `packaging <26.3`,
-  build number 0 -> 1, branch `unpin_packaging`): push, open the PR,
-  comment `@conda-forge-admin, please rerender`, merge on green. This is
-  the last `packaging <26.3` pin anywhere.
+- **Action:** branch `unpin_packaging` (71c4f71: `pyprms >=0.10.0`
+  replacing `packaging <26.3`, build number 0 -> 1) is pushed to the
+  `jmccreight` fork, but no PR was ever opened (verified 2026-08-19).
+  Open the PR against `conda-forge/pywatershed-feedstock`, comment
+  `@conda-forge-admin, please rerender`, merge on green. This is the
+  last `packaging <26.3` pin anywhere.
 
 ### pyPRMS upstream: close PR #64, port its regression test
 
-- **Blocked on:** coordination with pyPRMS maintainer (pnorton-usgs).
-  Check: state of DOI-USGS/pyPRMS PR #64.
-- **Action:** close #64 (superseded by the higher-level fix in commit
-  3650b285, released in 0.10.0) but port its regression test
+- **Blocked on:** nothing — #64 was closed unmerged 2026-08-17; the
+  regression test is not on pyPRMS main (verified 2026-08-19).
+- **Action:** port #64's regression test to pyPRMS via a fresh PR
   (`tests/func/test_Parameters.py::TestParametersSharedMetadata` — two
-  `Parameters` instances from one shared `MetaData` dict).
-
-### Publish gh-pages v3.0.0 extended release notes upstream
-
-- **Blocked on:** James's push access to `DOI-USGS/pywatershed`
-  `gh-pages` (org permission issue; the Actions "Run workflow" button is
-  also missing upstream — possibly the same knot; ask org admins).
-  Check: does `https://doi-usgs.github.io/pywatershed/` show the
-  2026-07-13 v3.0.0 post?
-- **Action:** `git push upstream gh-pages` (content is complete and
-  previewed at `jmccreight.github.io/pywatershed`). Then verify the links
-  in the GitHub 3.0.0 release body and `doc/index.rst` resolve. This is
-  the last step (9) of the 3.0.0 release.
+  `Parameters` instances from one shared `MetaData` dict; the fix
+  itself shipped in 0.10.0 via commit 3650b285).
 
 ### Reconcile check_version.yaml with release_preflight.sh
 
@@ -106,6 +94,11 @@ check it), **Action** (what to do once unblocked), and optional
 
 ## Done
 
+- 2026-08-19: gh-pages v3.0.0 extended release notes are live upstream
+  (`doi-usgs.github.io/pywatershed`, 2026-07-13 post) and all 3.0.0
+  release-body links resolve — step 9 done, the 3.0.0 release is
+  complete. (Push-access / "Run workflow" org questions moved into the
+  CI-usage item.)
 - 2026-08-19: PR #407's new sagehen CI jobs carry the skeleton/full
   `if:` gates (token `ci-sagehen`); its remaining ubuntu CI failure is
   being handled on the branch.

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -1,0 +1,125 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Maintenance ledger](#maintenance-ledger)
+  - [Open](#open)
+    - [3.0.1 hotfix release (flopy pin unwind + pyPRMS floor)](#301-hotfix-release-flopy-pin-unwind--pyprms-floor)
+    - [conda-forge feedstock: pyprms floor replaces packaging pin](#conda-forge-feedstock-pyprms-floor-replaces-packaging-pin)
+    - [PR #407 (cascades port): gate the new sagehen CI jobs](#pr-407-cascades-port-gate-the-new-sagehen-ci-jobs)
+    - [pyPRMS upstream: close PR #64, port its regression test](#pyprms-upstream-close-pr-64-port-its-regression-test)
+    - [Publish gh-pages v3.0.0 extended release notes upstream](#publish-gh-pages-v300-extended-release-notes-upstream)
+    - [Reconcile check_version.yaml with release_preflight.sh](#reconcile-check_versionyaml-with-release_preflightsh)
+    - [Deliver CI-usage findings to org admins](#deliver-ci-usage-findings-to-org-admins)
+  - [Done](#done)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+# Maintenance ledger
+
+Maintenance todos that are blocked on external events or span
+repositories, so they survive between sessions and maintainers. Each
+item states what unblocks it as a condition that can be checked
+mechanically (PyPI, conda-forge, or GitHub APIs). The `/maintenance`
+Claude skill (`.claude/skills/maintenance/`) walks this file, checks
+each condition live, and reports what is actionable; humans edit this
+file like any other (PRs to `develop`).
+
+Item format: a heading, then **Blocked on** (the condition and how to
+check it), **Action** (what to do once unblocked), and optional
+**Notes**. Move finished items to the Done section with a date.
+
+## Open
+
+### 3.0.1 hotfix release (flopy pin unwind + pyPRMS floor)
+
+- **Blocked on:** a flopy release containing modflowpy/flopy PR #2730
+  (wipe the dfn/toml dir in `generate_classes`). Check: latest version at
+  `https://pypi.org/pypi/flopy/json` is newer than 3.10.0 (Feb 2026) and
+  its changelog/commits include #2730.
+- **Action:** patch release `3.0.1` from `main` per `.github/RELEASE.md`
+  (the `/release` skill assists):
+  - Replace `"flopy[codegen] @ git+https://github.com/modflowpy/flopy.git"`
+    in `environment.yml` and `environment_w_jupyter.yml` with the released
+    floor (e.g. `flopy[codegen]>=X`). Leave the `mpsplines` git pin alone —
+    it is deliberate.
+  - Add a `pyPRMS >=0.10.0` floor to `pyproject.toml` on the release
+    branch: 3.0.0's published metadata has no floor, so installing an old
+    pyPRMS (<=0.9.10) with packaging >=26.3 still breaks; develop already
+    has the floor (PR #406).
+  - Afterwards: flopy floor + build-number bump on the conda-forge
+    pywatershed feedstock.
+- **Notes:** conda-forge flopy 3.10.0 predates the fix, so pywatershed
+  codegen paths (e.g. `MmrToMf6Dfw` class generation) are broken with
+  released flopy until then; flopy imports lazily so this is not an
+  import-time problem.
+
+### conda-forge feedstock: pyprms floor replaces packaging pin
+
+- **Blocked on:** nothing (pyprms 0.10.0 reached conda-forge 2026-08-18).
+  Check: `https://api.anaconda.org/package/conda-forge/pyprms` versions,
+  and PRs at `conda-forge/pywatershed-feedstock`.
+- **Action:** the edit exists in a local clone
+  (`recipe/meta.yaml`: `pyprms >=0.10.0` replacing `packaging <26.3`,
+  build number 0 -> 1, branch `unpin_packaging`): push, open the PR,
+  comment `@conda-forge-admin, please rerender`, merge on green. This is
+  the last `packaging <26.3` pin anywhere.
+
+### PR #407 (cascades port): gate the new sagehen CI jobs
+
+- **Blocked on:** merging `develop` (with the skeleton/full CI gates,
+  PR #408) into the `feat_cascades_port` branch. Check: PR #407 state and
+  whether its `ci.yaml` sagehen jobs carry `if:` gates.
+- **Action:** paste the domain-job `if:` gate (copy from any gated job in
+  `ci.yaml`) into each new sagehen job with token `ci-sagehen`; then test
+  with a push whose head commit message contains `ci-sagehen`. See
+  DEVELOPER.md under "CI".
+
+### pyPRMS upstream: close PR #64, port its regression test
+
+- **Blocked on:** coordination with pyPRMS maintainer (pnorton-usgs).
+  Check: state of DOI-USGS/pyPRMS PR #64.
+- **Action:** close #64 (superseded by the higher-level fix in commit
+  3650b285, released in 0.10.0) but port its regression test
+  (`tests/func/test_Parameters.py::TestParametersSharedMetadata` — two
+  `Parameters` instances from one shared `MetaData` dict).
+
+### Publish gh-pages v3.0.0 extended release notes upstream
+
+- **Blocked on:** James's push access to `DOI-USGS/pywatershed`
+  `gh-pages` (org permission issue; the Actions "Run workflow" button is
+  also missing upstream — possibly the same knot; ask org admins).
+  Check: does `https://doi-usgs.github.io/pywatershed/` show the
+  2026-07-13 v3.0.0 post?
+- **Action:** `git push upstream gh-pages` (content is complete and
+  previewed at `jmccreight.github.io/pywatershed`). Then verify the links
+  in the GitHub 3.0.0 release body and `doc/index.rst` resolve. This is
+  the last step (9) of the 3.0.0 release.
+
+### Reconcile check_version.yaml with release_preflight.sh
+
+- **Blocked on:** nothing; low priority.
+- **Action:** fold the legacy workflow's `doc/index.rst` major-release
+  check (exit code 7) into `.github/scripts/release_preflight.sh`, or
+  retire `check_version.yaml` in favor of the preflight + release.yaml
+  checks.
+
+### Deliver CI-usage findings to org admins
+
+- **Blocked on:** nothing; conversational.
+- **Action:** pywatershed is public and uses only standard runners, so
+  its minutes are free and cannot consume the org quota (proof: when the
+  org exhausted its minutes, private-repo Actions halted while
+  pywatershed kept running). The billing usage CSV attributes metered
+  minutes to the private repos that spent them. Org-shared runner
+  concurrency was addressed by PR #408 (skeleton/full split +
+  cancellation). Also raise the missing upstream push access /
+  "Run workflow" button.
+
+## Done
+
+- 2026-08-18: PR #406 (pyPRMS>=0.10.0 floor replaces packaging<26.3 in
+  pyproject + both env files) and PR #408 (CI skeleton/full split,
+  ci-tokens, concurrency cancellation) merged to develop.
+- 2026-08-18: pyPRMS 0.10.0 on PyPI and conda-forge; no pywatershed hot
+  release needed (3.0.0's published metadata never pinned packaging, so
+  fresh installs self-healed).

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -53,15 +53,13 @@ check it), **Action** (what to do once unblocked), and optional
 
 ### conda-forge feedstock: pyprms floor replaces packaging pin
 
-- **Blocked on:** nothing (pyprms 0.10.0 reached conda-forge 2026-08-18).
-  Check: `https://api.anaconda.org/package/conda-forge/pyprms` versions,
-  and PRs at `conda-forge/pywatershed-feedstock`.
-- **Action:** branch `unpin_packaging` (71c4f71: `pyprms >=0.10.0`
-  replacing `packaging <26.3`, build number 0 -> 1) is pushed to the
-  `jmccreight` fork, but no PR was ever opened (verified 2026-08-19).
-  Open the PR against `conda-forge/pywatershed-feedstock`, comment
-  `@conda-forge-admin, please rerender`, merge on green. This is the
-  last `packaging <26.3` pin anywhere.
+- **Blocked on:** feedstock PR #14 (pyprms >=0.10.0 floor, build 1)
+  MERGED 2026-08-19; awaiting the main-branch CI upload. Check:
+  `https://api.anaconda.org/package/conda-forge/pywatershed` shows a
+  3.0.0 build with build number 1.
+- **Action:** verify the new build's run deps carry `pyprms >=0.10.0`
+  and no `packaging <26.3`, then move to Done. This was the last
+  `packaging <26.3` pin anywhere.
 
 ### pyPRMS upstream: close PR #64, port its regression test
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -27,6 +27,11 @@ Bug fixes
 
 Internal changes
 ~~~~~~~~~~~~~~~~
+- Add ``MAINTENANCE.md``, a ledger of maintenance todos blocked on external
+  events (dependency releases, cross-repo work), each with a mechanically
+  checkable unblock condition; the ``/maintenance`` Claude skill checks them
+  live and reports what is actionable.
+  (:pull:`XXX`) By `James McCreight <https://github.com/jmccreight>`_.
 - Reduce CI footprint with a skeleton/full split: pushes to any branch (in
   this repository or on forks) run a skeleton — installs, linting, domainless
   tests, the docs build, and example notebooks on ubuntu only — while the


### PR DESCRIPTION
## Summary

Adds a repo-tracked ledger of maintenance todos that are blocked on
external events or span repositories, plus a Claude skill that works it.

**MAINTENANCE.md** (repo root): each item states a **Blocked on**
  condition written to be mechanically checkable (PyPI, conda-forge, and
  GitHub APIs) and an **Action** for when it unblocks. Seeded with the
  current open items: the 3.0.1 hotfix gated on flopy's next release, the
  conda-forge feedstock pin unwind, pyPRMS upstream tidy-up (#64 close +
  regression-test port), gh-pages v3.0.0 publication, and the
  check_version/preflight reconcile. Finished items move to a dated Done
  section.
**/maintenance skill** (.claude/skills/maintenance/): reads the
  ledger, checks each blocked-on condition live, reports
  actionable-now / still-blocked / done with evidence, drafts commands
  for actionable items, and updates the ledger (humans commit).

Rationale: these todos previously lived only in session memory of one
Claude instance on one machine. In the repo they are visible to all
maintainers, survive context loss, and are PR-reviewed like everything
else.

DEVELOPER.md and CLAUDE.md gained pointers.

## Checklist

[x] User visible changes are documented in whats-new.rst (`:pull:`XXX``
      placeholder — fill with this PR's number)

## Docs

Look for this PR number in our
[read-the-docs builds](https://app.readthedocs.org/projects/pywatershed/builds/)
where you can browse on-line.