### PR TITLE
Silence netCDF4 ndarray.shape DeprecationWarning at each write site

### DIFF
--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -109,21 +109,44 @@ check it), **Action** (what to do once unblocked), and optional
   for a tag above `v1.7.4rel`, then confirm the fix is in it, e.g. the
   released sdist no longer has `data.shape = tuple(datashape)` in
   `src/netCDF4/_netCDF4.pyx`.
-- **Action:** remove the
-  `ignore:Setting the shape on a NumPy array has been deprecated`
-  line (and the comment above the key) from `autotest/pytest.ini`, and
-  raise the netCDF4 floor in `environment.yml` to that release.
+- **Action:** delete `nc4_shape_warning_filter` (defined in
+  `pywatershed/base/data_model.py`) and unwrap every `with` that uses
+  it, re-dedenting the bodies; then raise the netCDF4 floor in
+  `environment.yml` to that release. Find them all with
+  `grep -rn nc4_shape_warning_filter pywatershed`. At the time of
+  writing, the uses are:
+  - `pywatershed/base/data_model.py`, `dd_to_nc4_ds`: combined into the
+    `with nc4.Dataset(nc_file, "w") as ds:` line.
+  - `pywatershed/utils/netcdf_utils.py`, class `NetCdfWrite`: the
+    coordinate writes in `__init__` (from `if nhru_coordinate:` through
+    the `extra_coords` loop), and the bodies of `add_simulation_time`,
+    `add_data`, and `add_all_data`.
+  - `pywatershed/base/budget.py`, `_output_netcdf` (the time write and
+    the variable loop).
+  - Imports of the name in `netcdf_utils.py` and `budget.py`.
+  - The `ignore:Setting the shape on a NumPy array has been deprecated`
+    line and its comment in `autotest/pytest.ini`, kept for xarray's
+    own `to_netcdf` path (`xarray/backends/netCDF4_.py`, `__setitem__`),
+    which pywatershed calls from about a dozen places and does not wrap.
 - **Notes:** netCDF4 assigns to `ndarray.shape` on every variable write
   (`_netCDF4.pyx:5616`), which NumPy >= 2.5 deprecates. Nothing on the
   pywatershed side avoids it: every assignment form was tried
   (`v[0,:] = a`, `v[0:1,:] = a[np.newaxis, ...]`, `v[0] = a`) and all
   warn, so the two sites the warning is attributed to,
-  `pywatershed/utils/netcdf_utils.py:660` and
-  `pywatershed/base/budget.py:944`, are correct as written -- the
+  `pywatershed/utils/netcdf_utils.py:669` and
+  `pywatershed/base/budget.py:950`, are correct as written -- the
   warning is raised in Cython and attributed to the nearest Python
   frame, which is ours. Observed with netCDF4 1.7.3 and NumPy 2.5.2:
   ~44,000 warnings in a single `test_prms_canopy.py` run. xarray took
   the same temporary measure (its PR #11146).
+  The suppression is per-write (`warnings.catch_warnings`) rather than
+  a pytest.ini filter because a global filter did not reach notebooks
+  (`autotest_exs/test_notebooks.py` runs them via ipython in a
+  subprocess) or users, and flopy 3.11 sets
+  `warnings.simplefilter("always", DeprecationWarning)` at import
+  (`flopy/utils/rasters.py:10` and two others), which overrides any
+  filter set earlier, including `PYTHONWARNINGS`. Reported informally
+  to the flopy developers, 2026-09-11.
 
 ### Drop the gfortran <16 ceiling (conda-forge win-64 link failure)
 

--- a/autotest/pytest.ini
+++ b/autotest/pytest.ini
@@ -2,11 +2,9 @@
 markers =
     domainless: tests not requiring input from domain files
     domain: tests requiring input from domain files
-# The netCDF4 filter below: netCDF4 assigns to ndarray.shape (_netCDF4.pyx
-# line 5616) on every variable write, which NumPy >= 2.5 deprecates. Fixed
-# upstream by netcdf4-python PR #1469, merged 2026-02-17 and unreleased as
-# of 1.7.4; xarray silences it the same way (its PR #11146). Drop this line
-# once the netCDF4 release carrying the fix is required. See MAINTENANCE.md.
+# xarray's netCDF4 backend (xarray/backends/netCDF4_.py, __setitem__) hits
+# the same netCDF4 ndarray.shape deprecation as our own writes; the
+# pywatershed sites are wrapped in code, see MAINTENANCE.md. Drop with it.
 filterwarnings =
     ignore:Setting the shape on a NumPy array has been deprecated:DeprecationWarning
     ignore:.*is not an available control option:UserWarning

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -55,7 +55,7 @@ Bug fixes
   is applied around each write in code, not only as a pytest filter,
   because flopy sets ``warnings.simplefilter("always",
   DeprecationWarning)`` at import and overrides any earlier filter; see
-  ``MAINTENANCE.md`` for when it can be removed. (:pull:`XXX`) By `James
+  ``MAINTENANCE.md`` for when it can be removed. (:pull:`419`) By `James
   McCreight
   <https://github.com/jmccreight>`_.
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -49,6 +49,15 @@ Bug fixes
   intercepted. :class:`PRMSSnow` now declares ``pkwater_ante``, as
   ``snowcomp`` does (``snowcomp.f90:346-349``), so coupled models supply it.
   (:pull:`414`) By `James McCreight <https://github.com/jmccreight>`_.
+- NetCDF output no longer floods the console with NumPy's ``Setting the
+  shape on a NumPy array has been deprecated`` warning (one per variable
+  per timestep with netCDF4 <= 1.7.4 and NumPy >= 2.5). The suppression
+  is applied around each write in code, not only as a pytest filter,
+  because flopy sets ``warnings.simplefilter("always",
+  DeprecationWarning)`` at import and overrides any earlier filter; see
+  ``MAINTENANCE.md`` for when it can be removed. (:pull:`XXX`) By `James
+  McCreight
+  <https://github.com/jmccreight>`_.
 
 Internal changes
 ~~~~~~~~~~~~~~~~

--- a/pywatershed/base/budget.py
+++ b/pywatershed/base/budget.py
@@ -11,6 +11,7 @@ from pywatershed.base.control import Control
 from ..constants import zero
 from ..utils.netcdf_utils import NetCdfWrite
 from .accessor import Accessor
+from .data_model import nc4_shape_warning_filter
 from .parameters import Parameters
 
 # Todo
@@ -935,21 +936,25 @@ class Budget(Accessor):
             self._netcdf.time[self.control.itime_step] = nc4.date2num(
                 self.control.current_datetime, self._netcdf.time.units
             )
-            for nc_group, group_vars in self._netcdf_output_var_dict.items():
-                for nc_var in group_vars:
-                    var_self_name = nc_var
+            with nc4_shape_warning_filter():
+                for (
+                    nc_group,
+                    group_vars,
+                ) in self._netcdf_output_var_dict.items():
+                    for nc_var in group_vars:
+                        var_self_name = nc_var
 
-                    if nc_group is None:
-                        var_path = nc_var
-                        self._netcdf.dataset[var_path][
-                            self.control.itime_step, :
-                        ] = self[var_self_name]
+                        if nc_group is None:
+                            var_path = nc_var
+                            self._netcdf.dataset[var_path][
+                                self.control.itime_step, :
+                            ] = self[var_self_name]
 
-                    else:
-                        var_path = f"{nc_group}/{nc_var}"
-                        self._netcdf.dataset[var_path][
-                            self.control.itime_step, :
-                        ] = self[nc_group][var_self_name]
+                        else:
+                            var_path = f"{nc_group}/{nc_var}"
+                            self._netcdf.dataset[var_path][
+                                self.control.itime_step, :
+                            ] = self[nc_group][var_self_name]
 
         return
 

--- a/pywatershed/base/data_model.py
+++ b/pywatershed/base/data_model.py
@@ -1,4 +1,5 @@
 import warnings
+from contextlib import contextmanager
 from copy import deepcopy
 from typing import Iterable, Literal
 
@@ -9,6 +10,27 @@ import xarray as xr
 
 from ..constants import fileish, fill_values_dict, np_type_to_netcdf_type_dict
 from .accessor import Accessor
+
+
+@contextmanager
+def nc4_shape_warning_filter():
+    """Silence netCDF4's ndarray.shape DeprecationWarning during a write.
+
+    netCDF4 <= 1.7.4 assigns to ndarray.shape on every variable write,
+    which NumPy >= 2.5 deprecates; fixed upstream in netcdf4-python PR
+    #1469, unreleased. A global filter is not enough: flopy calls
+    warnings.simplefilter("always", DeprecationWarning) at import, which
+    overrides any filter set before it. Remove with the netCDF4 floor
+    raise; see MAINTENANCE.md.
+    """
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="Setting the shape on a NumPy array has been deprecated",
+            category=DeprecationWarning,
+        )
+        yield
+
 
 # This file defines the data model for pywatershed. It is called a
 # "dataset_dict" and has a invertible mapping with non-hierarchical netcdf
@@ -1051,7 +1073,7 @@ def dd_to_nc4_ds(dd, nc_file):
     del dd
 
     # create a new netCDF4 file
-    with nc4.Dataset(nc_file, "w") as ds:
+    with nc4_shape_warning_filter(), nc4.Dataset(nc_file, "w") as ds:
         ds.set_fill_on()
 
         for key, value in xr_dd["attrs"].items():

--- a/pywatershed/utils/netcdf_utils.py
+++ b/pywatershed/utils/netcdf_utils.py
@@ -8,11 +8,14 @@ import numpy as np
 import xarray as xr
 
 from ..base.accessor import Accessor
+from ..base.data_model import nc4_shape_warning_filter
 from ..base.meta import meta_dimensions, meta_netcdf_type
 from ..constants import np_type_to_netcdf_type_dict
 from ..utils.time_utils import datetime_doy
 
 fileish = Union[str, pl.Path]
+
+
 listish = Union[list, tuple]
 arrayish = Union[list, tuple, np.ndarray]
 ATOL = np.finfo(np.float32).eps
@@ -500,77 +503,79 @@ class NetCdfWrite(Accessor):
         if nnodes_coordinate:
             self.dataset.createDimension("node_coord", self.nnodes)
 
-        if nhru_coordinate:
-            self.hruid = self.dataset.createVariable(
-                "nhm_id", "i4", ("nhm_id",)
-            )
-            self.hruid[:] = np.array(self.hru_ids, dtype=int)
-        if nsegment_coordinate:
-            self.segid = self.dataset.createVariable(
-                "nhm_seg", "i4", ("nhm_seg",)
-            )
-            self.segid[:] = np.array(self.segment_ids, dtype=int)
-        if one_coordinate:
-            self.oneid = self.dataset.createVariable("one", "i4", ("one"))
-            self.oneid[:] = np.array(self.one_ids, dtype=int)
-        if nreservoirs_coordinate:
-            self.grandid = self.dataset.createVariable(
-                "grand_id", "i4", ("grand_id",)
-            )
-            self.grandid[:] = coordinates["grand_id"]
-        if nnodes_coordinate:
-            self.node_coord = self.dataset.createVariable(
-                "node_coord", "i4", ("node_coord",)
-            )
-            self.node_coord[:] = coordinates["node_coord"]
-
-        char_dims_created = []
-        for x_dim, x_data_dict in extra_coords.items():
-            for x_var_name, x_data in x_data_dict.items():
-                type = x_data.dtype
-                type_str = str(type)
-
-                dim = (x_dim,)
-                if "U" in type_str or "S" in type_str:
-                    # https://unidata.github.io/netcdf4-python/#dealing-with-strings  # noqa: E501
-                    # S1 gives "char" type in the file whereas another
-                    # number gives "string" type. The former is properly
-                    # handled by xarray
-                    nc_type = "S1"
-
-                    # if it is a string array, convert it to a character array
-                    # I dont understand the particulars here, may need more
-                    # work
-                    # Convert Unicode strings to UTF-8 byte strings first
-                    if "U" in type_str:
-                        x_data = np.char.encode(x_data, "utf-8")
-                    char_array = stringtochar(x_data)
-
-                    char_dim_len = char_array.shape[1]
-                    dim_name = f"char{char_dim_len}"
-                    if dim_name in char_dims_created:
-                        continue
-
-                    dim = (x_dim, dim_name)
-                    _ = self.dataset.createDimension(
-                        dimname=dim_name, size=char_dim_len
-                    )
-
-                    char_dims_created += [dim_name]
-
-                else:
-                    nc_type = np_type_to_netcdf_type_dict[type]
-
-                # <
-                self[x_var_name] = self.dataset.createVariable(
-                    varname=x_var_name, datatype=nc_type, dimensions=dim
+        with nc4_shape_warning_filter():
+            if nhru_coordinate:
+                self.hruid = self.dataset.createVariable(
+                    "nhm_id", "i4", ("nhm_id",)
                 )
-                if "S1" == nc_type:
-                    self[x_var_name][:, :] = char_array
-                    self[x_var_name]._Encoding = "utf-8"
+                self.hruid[:] = np.array(self.hru_ids, dtype=int)
+            if nsegment_coordinate:
+                self.segid = self.dataset.createVariable(
+                    "nhm_seg", "i4", ("nhm_seg",)
+                )
+                self.segid[:] = np.array(self.segment_ids, dtype=int)
+            if one_coordinate:
+                self.oneid = self.dataset.createVariable("one", "i4", ("one"))
+                self.oneid[:] = np.array(self.one_ids, dtype=int)
+            if nreservoirs_coordinate:
+                self.grandid = self.dataset.createVariable(
+                    "grand_id", "i4", ("grand_id",)
+                )
+                self.grandid[:] = coordinates["grand_id"]
+            if nnodes_coordinate:
+                self.node_coord = self.dataset.createVariable(
+                    "node_coord", "i4", ("node_coord",)
+                )
+                self.node_coord[:] = coordinates["node_coord"]
 
-                else:
-                    self[x_var_name][:] = x_data
+            char_dims_created = []
+            for x_dim, x_data_dict in extra_coords.items():
+                for x_var_name, x_data in x_data_dict.items():
+                    type = x_data.dtype
+                    type_str = str(type)
+
+                    dim = (x_dim,)
+                    if "U" in type_str or "S" in type_str:
+                        # https://unidata.github.io/netcdf4-python/#dealing-with-strings  # noqa: E501
+                        # S1 gives "char" type in the file whereas another
+                        # number gives "string" type. The former is properly
+                        # handled by xarray
+                        nc_type = "S1"
+
+                        # if it is a string array, convert it to a character
+                        # array
+                        # I dont understand the particulars here, may need more
+                        # work
+                        # Convert Unicode strings to UTF-8 byte strings first
+                        if "U" in type_str:
+                            x_data = np.char.encode(x_data, "utf-8")
+                        char_array = stringtochar(x_data)
+
+                        char_dim_len = char_array.shape[1]
+                        dim_name = f"char{char_dim_len}"
+                        if dim_name in char_dims_created:
+                            continue
+
+                        dim = (x_dim, dim_name)
+                        _ = self.dataset.createDimension(
+                            dimname=dim_name, size=char_dim_len
+                        )
+
+                        char_dims_created += [dim_name]
+
+                    else:
+                        nc_type = np_type_to_netcdf_type_dict[type]
+
+                    # <
+                    self[x_var_name] = self.dataset.createVariable(
+                        varname=x_var_name, datatype=nc_type, dimensions=dim
+                    )
+                    if "S1" == nc_type:
+                        self[x_var_name][:, :] = char_array
+                        self[x_var_name]._Encoding = "utf-8"
+
+                    else:
+                        self[x_var_name][:] = x_data
 
         self.variables = {}
         for var_name, group_var_name in zip(variables, group_variables):
@@ -639,7 +644,10 @@ class NetCdfWrite(Accessor):
             return
 
     def add_simulation_time(self, itime_step: int, simulation_time: float):
-        self.time[itime_step] = nc4.date2num(simulation_time, self.time.units)
+        with nc4_shape_warning_filter():
+            self.time[itime_step] = nc4.date2num(
+                simulation_time, self.time.units
+            )
         return
 
     def add_data(
@@ -657,7 +665,8 @@ class NetCdfWrite(Accessor):
         if name not in self.variables.keys():
             raise KeyError(f"{name} not a valid variable name")
         var = self.variables[name]
-        var[itime_step, :] = current[:]
+        with nc4_shape_warning_filter():
+            var[itime_step, :] = current[:]
         return
 
     def add_all_data(
@@ -678,21 +687,24 @@ class NetCdfWrite(Accessor):
         if name not in self.variables.keys():
             raise KeyError(f"{name} not a valid variable name")
 
-        if time_coord == "time":
-            start_date = (
-                time_data[0].astype(dt.datetime).strftime("%Y-%m-%d %H:%M:%S")
-            )
-            self[time_coord].units = f"days since {start_date}"
-            self[time_coord][:] = nc4.date2num(
-                time_data.astype(dt.datetime),
-                units=self[time_coord].units,
-                calendar="standard",
-            )
-        else:
-            # currently just doy
-            self[time_coord][:] = time_data
+        with nc4_shape_warning_filter():
+            if time_coord == "time":
+                start_date = (
+                    time_data[0]
+                    .astype(dt.datetime)
+                    .strftime("%Y-%m-%d %H:%M:%S")
+                )
+                self[time_coord].units = f"days since {start_date}"
+                self[time_coord][:] = nc4.date2num(
+                    time_data.astype(dt.datetime),
+                    units=self[time_coord].units,
+                    calendar="standard",
+                )
+            else:
+                # currently just doy
+                self[time_coord][:] = time_data
 
-        self.variables[name][:, :] = data[:, :]
+            self.variables[name][:, :] = data[:, :]
 
         return
 


### PR DESCRIPTION
With netCDF4 <= 1.7.4 and NumPy >= 2.5 every netCDF variable write emits
Setting the shape on a NumPy array has been deprecated (netCDF4 assigns
to ndarray.shape in _netCDF4.pyx; fixed upstream in
Unidata/netcdf4-python#1469, unreleased). The pytest.ini filter hid it
in the test suite only: the example notebooks (run by
autotest_exs/test_notebooks.py via ipython in a subprocess) and any user
script still got one warning per variable per timestep.

A global filter cannot fix this. flopy 3.11 runs
warnings.simplefilter("always", DeprecationWarning) at import
(flopy/utils/rasters.py:10, flopy/mf6/utils/binarygrid_util.py:14,
flopy/export/vtk.py:17), which is inserted ahead of any filter set
earlier, including PYTHONWARNINGS, and import pywatershed imports
flopy. Reported informally to the flopy developers.

Changes:
nc4_shape_warning_filter, a warnings.catch_warnings context manager
  in pywatershed/base/data_model.py, wraps every pywatershed netCDF4
  write: NetCdfWrite (coordinate writes, add_simulation_time,
  add_data, add_all_data), Budget._output_netcdf, and
  dd_to_nc4_ds. It is inserted at write time, so import order does
  not matter.
The pytest.ini line is kept only for xarray's own to_netcdf path
  (xarray/backends/netCDF4_.py, __setitem__), which pywatershed
  calls from about a dozen places and does not wrap.
MAINTENANCE.md lists every site (and a grep to find them) for
  removal once the netCDF4 release carrying the fix is required.

Verified: 01_multi-process_models.ipynb runs clean;
pytest test_prms_canopy.py test_model.py --domain drb_2yr shows zero
occurrences and passes with -W error::DeprecationWarning:pywatershed.

Docs build for this PR: https://app.readthedocs.org/projects/pywatershed/builds/34520888/
Rendered: https://pywatershed--419.org.readthedocs.build/en/419/

## Checklist

[x] Closes #418
[ ] ~~Tests added~~
[ ] ~~Performance benchmarks added or run~~
[x] User visible changes (including notable bug fixes) are documented in whats-new.rst
[x] The ``(:pull:XXX)`` placeholder in whats-new.rst is replaced with this PR's number
[ ] ~~New public classes/functions are exported in pywatershed/__init__.py and listed in doc/api/*.rst~~

